### PR TITLE
docs(aliasing): fix description of alias syntax

### DIFF
--- a/www/src/pages/docs/tokens/index.md
+++ b/www/src/pages/docs/tokens/index.md
@@ -405,7 +405,7 @@ _Should a type be added? [Suggest it be added!](https://github.com/design-tokens
 
 ## Aliasing
 
-Types can be aliased [as defined in the Design Tokens spec](https://design-tokens.github.io/community-group/format/#aliases-references) by using the JSON pointer syntax:
+Types can be aliased [as defined in the Design Tokens spec](https://design-tokens.github.io/community-group/format/#aliases-references) by using dot-delimited path syntax, wrapped in curly braces (e.g., `{groupA.groupB.token}`):
 
 ```json
 {


### PR DESCRIPTION
Aliasing docs claim that it uses JSON pointer syntax, but that is incorrect. The spec mentions that the community group is currently _researching_ the use of JSON pointer syntax for aliases, but [hasn't made it official](https://design-tokens.github.io/community-group/format/#aliases-references) (see screenshot).

![PixelSnap 2022-06-03 at 09 49 30@2x](https://user-images.githubusercontent.com/545605/171878193-ee31f8a5-5b38-4881-b405-527386a21f97.png)

This PR is an attempt in updating the wording to reflect the _current_, dot-delimited path syntax.