### PR TITLE
Fix typeof check

### DIFF
--- a/packages/utils/src/ansi.ts
+++ b/packages/utils/src/ansi.ts
@@ -1,4 +1,4 @@
-export const COLOR_ENABLED = typeof process !== undefined ? !process.env.NODE_DISABLE_COLORS && (!process.env.NO_COLOR || process.env.NO_COLOR == "0") : true;
+export const COLOR_ENABLED = typeof process !== 'undefined' ? !process.env.NODE_DISABLE_COLORS && (!process.env.NO_COLOR || process.env.NO_COLOR == "0") : true;
 
 export const RESET      = COLOR_ENABLED ? '\u001b[0m'  : '';
 export const BOLD       = COLOR_ENABLED ? '\u001b[1m'  : '';


### PR DESCRIPTION
Fixed a `typeof` check that was failing when running in a browser, where `process` is undefined.

*I didn't get a PR template or checklist, but let me know if you want additional info*