### PR TITLE
Make meta fields optional for JS

### DIFF
--- a/.changeset/dirty-dogs-switch.md
+++ b/.changeset/dirty-dogs-switch.md
@@ -1,0 +1,5 @@
+---
+'@cobalt-ui/plugin-js': minor
+---
+
+Allow meta fields to not be generated for javascript builds

--- a/packages/plugin-js/src/index.ts
+++ b/packages/plugin-js/src/index.ts
@@ -169,7 +169,7 @@ export default function pluginJS(options?: Options): Plugin {
               '',
               `export const tokens = ${serializeJS(js.tokens, {comments: jsDoc})}`,
               '',
-              ...(!!js.meta ? [`export const meta = ${serializeJS(js.meta)}`, ''] : []),
+              ...(js.meta ? [`export const meta = ${serializeJS(js.meta)}`, ''] : []),
               `export const modes = ${Object.keys(js.modes).length ? serializeJS(js.modes) : `{};`}`,
               '',
               `/** Get individual token */
@@ -193,7 +193,7 @@ export function token(tokenID, modeName) {
               ...ts.tokens,
               '};',
               '',
-              ...(!!ts.meta ? ['export declare const meta: {', ...ts.meta, '};', ''] : []),
+              ...(ts.meta ? ['export declare const meta: {', ...ts.meta, '};', ''] : []),
               `export declare const modes: ${ts.modes.length ? `{\n${ts.modes.join('\n')}\n}` : 'Record<string, never>'};`,
               '',
               `export declare function token<K extends keyof typeof tokens>(tokenID: K, modeName?: never): typeof tokens[K];`,


### PR DESCRIPTION
This adds a new option to the js plugin to disable `meta` from being generated. For projects where tree-shaking is non-existent or doesn't work well, the meta object takes up a lot of space and probably isn't used much.

I'm not in love with the implementation at all really, so if you have thoughts on better ways to approach this, I'm happy to hear them! This approach was the best way to preserve order (i.e. not throwing meta at the bottom), but maybe that doesn't matter at all.