### PR TITLE
Fix Tokens Studio opacity token, update docs

### DIFF
--- a/.changeset/wet-maps-try.md
+++ b/.changeset/wet-maps-try.md
@@ -1,0 +1,5 @@
+---
+'@cobalt-ui/core': patch
+---
+
+Fix Tokens Studio opacity token type

--- a/.changeset/witty-suits-punch.md
+++ b/.changeset/witty-suits-punch.md
@@ -1,0 +1,5 @@
+---
+'@cobalt-ui/core': patch
+---
+
+Fix bug where `$type: number, $value: 0` was treated as a missing value

--- a/docs/src/components/Token.astro
+++ b/docs/src/components/Token.astro
@@ -22,11 +22,42 @@ const {type: tokenType} = Astro.props;
     ]
   }
   {
-    ['dimension', 'duration', 'link'].includes(tokenType) && [
+    ['dimension', 'duration'].includes(tokenType) && [
       <svg class="token-bg">
         <use xlink:href="#hex" />
       </svg>,
       <div class="token-fg" />,
+    ]
+  }
+  {
+    tokenType === 'number' && [
+      <svg class="token-bg">
+        <use xlink:href="#hex" />
+      </svg>,
+      <div class="token-fg">
+        <div class="token-fg-dot" />
+        <div class="token-fg-dot" style="animation-delay: 50ms" />
+        <div class="token-fg-dot" style="animation-delay: 100ms" />
+        <div class="token-fg-dot" style="animation-delay: 50ms" />
+        <div class="token-fg-dot" style="animation-delay: 100ms" />
+        <div class="token-fg-dot" style="animation-delay: 150ms" />
+        <div class="token-fg-dot" style="animation-delay: 100ms" />
+        <div class="token-fg-dot" style="animation-delay: 150ms" />
+        <div class="token-fg-dot" style="animation-delay: 200ms" />
+      </div>,
+    ]
+  }
+  {
+    tokenType === 'link' && [
+      <svg class="token-bg">
+        <use xlink:href="#hex" />
+      </svg>,
+      <div class="token-fg">
+        <div class="token-fg-dot-1" />
+        <div class="token-fg-dot-2" />
+        <div class="token-fg-dot-3" />
+        <div class="token-fg-dot-4" />
+      </div>,
     ]
   }
   {
@@ -101,11 +132,13 @@ const {type: tokenType} = Astro.props;
       }
     }
 
-    &--font,
+    &--fontFamily,
+    &--fontWeight,
     &--typography {
       .token-fg {
-        font-size: 19px;
-        font-weight: 600;
+        animation: embolden token('ease.linear') infinite 2s;
+        font-size: 19px !important;
+        font-weight: 400;
         letter-spacing: -0.0125em;
       }
     }
@@ -150,6 +183,26 @@ const {type: tokenType} = Astro.props;
       }
     }
 
+    &--number {
+      .token-fg {
+        display: grid;
+        gap: 0.0625rem;
+        grid-template-columns: repeat(3, 1fr);
+        grid-template-rows: repeat(3, 1fr);
+        justify-items: center;
+        padding: 0.25rem;
+
+        &-dot {
+          --size: 0.25rem;
+          animation: shrink token('ease.inOutCirc') infinite 2s;
+          background-color: currentColor;
+          border-radius: 50%;
+          height: var(--size);
+          width: var(--size);
+        }
+      }
+    }
+
     &--cubic-bezier {
       .token-fg {
         animation: flip token('ease.inOutCirc') infinite 2s;
@@ -163,34 +216,35 @@ const {type: tokenType} = Astro.props;
 
     &--link {
       .token-fg {
-        animation: spin token('ease.inOutCubic') infinite 2s;
-        background: conic-gradient(var(--ui-bg), var(--ui-bg) 120deg, var(--ui-fg));
-        border-radius: 50%;
-        height: 50%;
-        width: 50%;
-
-        &::before {
-          background: var(--ui-fg);
+        &-dot-1,
+        &-dot-2,
+        &-dot-3,
+        &-dot-4 {
+          --size: #{math.div(10rem, 32)};
+          animation: spin token('ease.inOutCubic') infinite 2s;
+          background-color: currentColor;
           border-radius: 50%;
-          content: '';
-          height: 18.75%;
+          height: var(--size);
           left: 50%;
-          position: absolute;
-          top: 0;
-          transform: translate3d(-50%, 0, 0);
-          width: 18.75%;
-        }
-
-        &::after {
-          background: var(--ui-bg);
-          border-radius: 50%;
-          content: '';
-          height: 62.5%;
-          left: 50%;
+          margin-left: calc(-0.5 * var(--size));
+          margin-top: calc(-0.5 * var(--size));
           position: absolute;
           top: 50%;
-          transform: translate3d(-50%, -50%, 0);
-          width: 62.5%;
+          transform: translate3d(-50%, -1rem, 0);
+          width: var(--size);
+        }
+
+        &-dot-2 {
+          --size: #{math.div(9rem, 32)};
+          animation-delay: 50ms;
+        }
+        &-dot-3 {
+          --size: #{math.div(8rem, 32)};
+          animation-delay: 100ms;
+        }
+        &-dot-4 {
+          --size: #{math.div(7rem, 32)};
+          animation-delay: 150ms;
         }
       }
     }
@@ -246,6 +300,16 @@ const {type: tokenType} = Astro.props;
         position: relative;
         z-index: 10;
       }
+    }
+  }
+
+  @keyframes embolden {
+    0%,
+    100% {
+      font-weight: 1;
+    }
+    50% {
+      font-weight: 999;
     }
   }
 
@@ -381,12 +445,22 @@ const {type: tokenType} = Astro.props;
     }
   }
 
+  @keyframes shrink {
+    0%,
+    100% {
+      transform: scale(0.25);
+    }
+    50% {
+      transform: scale(1);
+    }
+  }
+
   @keyframes spin {
     0% {
-      transform: translate3d(-50%, -50%, 0) rotate(0deg);
+      transform: rotate(0deg) translate3d(0, -0.375rem, 0);
     }
     100% {
-      transform: translate3d(-50%, -50%, 0) rotate(1080deg);
+      transform: rotate(1080deg) translate3d(0, -0.375rem, 0);
     }
   }
 

--- a/docs/src/pages/docs/guides/tokens-studio.md
+++ b/docs/src/pages/docs/guides/tokens-studio.md
@@ -22,6 +22,21 @@ export default {
 };
 ```
 
-> ⚠️ **Compatibility Warning**
->
-> While Cobalt will do the best job it can converting from Tokens Studio for Figma’s format, some types may be incompatible. If you encounter any problems, please [file an issue](https://github.com/drwpow/cobalt-ui/issues).
+## Compatibility
+
+| Token Studio Token                                                                | Supported | Notes                                                                                                                                                                    |
+| :-------------------------------------------------------------------------------- | :-------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Sizing](https://docs.tokens.studio/available-tokens/sizing-tokens)               |    ✅     | Converted to [Dimension](/docs/tokens/#dimension).                                                                                                                       |
+| [Spacing](https://docs.tokens.studio/available-tokens/spacing-tokens)             |    ✅     | Converted to [Dimension](/docs/tokens/#dimension).                                                                                                                       |
+| [Color](https://docs.tokens.studio/available-tokens/color-tokens)                 |    ✅     | Flat colors are kept as [Color](/docs/tokens/#color) while gradients are converted to [Gradient](/docs/tokens/#gradient). Modifiers aren’t supported.                    |
+| [Border radius](https://docs.tokens.studio/available-tokens/border-radius-tokens) |    ✅     | Converted to [Dimension](/docs/tokens/#dimension). Multiple values are expanded into 4 tokens (`*TopLeft`, `*TopRight`, `*BottomLeft`, `*BottomRight`).                  |
+| [Border width](https://docs.tokens.studio/available-tokens/border-width-tokens)   |    ✅     | Converted to [Dimension](/docs/tokens/#dimension).                                                                                                                       |
+| [Shadow](https://docs.tokens.studio/available-tokens/shadow-tokens)               |    ✅     | Basically equivalent to [Shadow](/docs/tokens/#shadow).                                                                                                                  |
+| [Opacity](https://docs.tokens.studio/available-tokens/opacity-tokens)             |    ✅     | Converted to [Number](/docs/tokens/#number)                                                                                                                              |
+| [Typography](https://docs.tokens.studio/available-tokens/typography-tokens)       |    ✅     | Basically equivalent to [Typography](/docs/tokens/#typography). **Text decoration** and **Text Case** must be flattened as there is no W3C Design Token spec equivalent. |
+| [Asset](https://docs.tokens.studio/available-tokens/asset-tokens)                 |    ❌     | TODO. Cobalt supports [Link](/docs/tokens/#link), which should be an equivalent.                                                                                         |
+| [Composition](https://docs.tokens.studio/available-tokens/composition-tokens)     |    ❌     | Unsupported because this is a paid feature.                                                                                                                              |
+| [Dimension](https://docs.tokens.studio/available-tokens/dimension-tokens)         |    ✅     | Direct equivalent to [Dimension](/docs/tokens/#dimension).                                                                                                               |
+| [Border](https://docs.tokens.studio/available-tokens/border-tokens)               |    ✅     | Direct equivalent to [Border](/docs/tokens/#border).                                                                                                                     |
+
+Note that **Duration** and **Cubic Bezier** aren’t supported by Tokens Studio (because Figma currently doesn’t support animations). So to use those types you’ll need to convert your tokens into the W3C Design Token format.

--- a/docs/src/pages/docs/tokens/index.astro
+++ b/docs/src/pages/docs/tokens/index.astro
@@ -82,7 +82,7 @@ const tokenDef = {
 
   <h2 id="font">
     <Token type="fontFamily" />
-    Font
+    Font Family
   </h2>
 
   <p>A font name as defined in <a href={tokenDef.fontFamily} target="_blank"><b>8.3</b></a>.</p>
@@ -123,7 +123,7 @@ const tokenDef = {
 
   <h2 id="font-weight">
     <Token type="fontWeight" />
-    Font
+    Font Weight
   </h2>
 
   <p>A font weight as defined in <a href={tokenDef.fontWeight} target="_blank"><b>8.4</b></a>.</p>
@@ -297,7 +297,7 @@ const tokenDef = {
 
   <h2 id="number">
     <Token type="number" />
-    Duration
+    Number
   </h2>
 
   <p>A number as defined in <a href={tokenDef.number} target="_blank"><b>8.7</b></a>.</p>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -1,14 +1,10 @@
 ---
-import DocsPagination from '../components/DocsPagination.astro';
 import Footer from '../components/Footer.astro';
 import Head from '../components/Head.astro';
 import Nav from '../components/Nav.astro';
 import SkipToMain from '../components/SkipToMain.astro';
 import Token from '../components/Token.astro';
 
-import packageJSON from '../../../packages/cli/package.json';
-
-const version = packageJSON.version;
 const tokenTypes = ['color', 'color', 'fontFamily', 'fontFamily', 'fontWeight', 'fontWeight', 'dimension', 'duration', 'link', 'cubic-bezier', 'shadow', 'border', 'stroke-style', 'transition', 'empty', 'empty', 'empty', 'empty', 'empty'];
 ---
 

--- a/packages/core/src/parse/tokens-studio.ts
+++ b/packages/core/src/parse/tokens-studio.ts
@@ -135,18 +135,19 @@ export function convertTokensStudioFormat(rawTokens: Record<string, unknown>): {
           case 'fontSizes':
           case 'letterSpacing':
           case 'lineHeights':
+          case 'opacity':
           case 'sizing': {
-            addToken({$type: 'dimension', $value: v.value === '0' ? 0 : v.value}, [...path, k]);
+            // this is a number if this is unitless
+            const isNumber = typeof v.value === 'number' || (typeof v.value === 'string' && String(Number(v.value)) === v.value);
+            if (isNumber) {
+              addToken({$type: 'number', $value: Number(v.value)}, [...path, k]);
+            } else {
+              addToken({$type: 'dimension', $value: v.value}, [...path, k]);
+            }
             break;
           }
           case 'fontWeights': {
             addToken({$type: 'fontWeight', $value: parseInt(v.value, 10) || v.value}, [...path, k]);
-            break;
-          }
-          // unsupported
-          case 'opacity': {
-            // @ts-expect-error this should throw a warning
-            addToken({$type: 'opacity', $value: v.value}, [...path, k]);
             break;
           }
           case 'spacing': {

--- a/packages/core/src/parse/tokens/number.ts
+++ b/packages/core/src/parse/tokens/number.ts
@@ -18,7 +18,7 @@ import type {ParsedNumberToken} from '../../token.js';
  * }
  */
 export function normalizeNumberValue(value: unknown): ParsedNumberToken['$value'] {
-  if (!value) throw new Error('missing value');
+  if (value === null || value === undefined) throw new Error('missing value');
   if (typeof value === 'number') return value;
   throw new Error(`expected number, received ${typeof value}`);
 }

--- a/packages/core/test/tokens-studio.test.js
+++ b/packages/core/test/tokens-studio.test.js
@@ -38,7 +38,7 @@ describe('Sizing', () => {
     const tokens = getTokens(json);
 
     expect(tokens.find((t) => t.id === 'global.sizing.s')).toEqual(expect.objectContaining({$type: 'dimension', $value: '8px'}));
-    expect(tokens.find((t) => t.id === 'global.sizing.m')).toEqual(expect.objectContaining({$type: 'dimension', $value: '16'}));
+    expect(tokens.find((t) => t.id === 'global.sizing.m')).toEqual(expect.objectContaining({$type: 'number', $value: 16}));
     expect(tokens.find((t) => t.id === 'global.sizing.l')).toEqual(expect.objectContaining({$type: 'dimension', $value: '2rem'}));
   });
 });
@@ -194,6 +194,18 @@ describe('Color', () => {
       };
       const tokens = getTokens(json);
       expect(tokens.find((t) => t.id === 'global.borderWidth')).toEqual(expect.objectContaining({$type: 'dimension', $value: '1px'}));
+    });
+  });
+
+  describe('Opacity', () => {
+    test('basic', () => {
+      const json = {
+        global: {
+          opacity: {50: {type: 'opacity', value: 0.5}},
+        },
+      };
+      const tokens = getTokens(json);
+      expect(tokens.find((t) => t.id === 'global.opacity.50')).toEqual(expect.objectContaining({$type: 'number', $value: 0.5}));
     });
   });
 


### PR DESCRIPTION
Adds support for [Opacity](https://docs.tokens.studio/available-tokens/opacity-tokens) tokens in Tokens Studio using the `number` token type.

Also fixes a `number` token type bug, and updates docs.