### PR TITLE
Fix @cobalt-ui/core main package import

### DIFF
--- a/.changeset/ninety-pillows-hang.md
+++ b/.changeset/ninety-pillows-hang.md
@@ -1,0 +1,6 @@
+---
+'@cobalt-ui/core': patch
+'@cobalt-ui/cli': patch
+---
+
+Fix @cobalt-ui/core package import

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,8 +25,7 @@
   "homepage": "https://cobalt-ui.pages.dev",
   "license": "MIT",
   "type": "module",
-  "main": "./dist/index.min.js",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "scripts": {
     "build": "tsc && npm run bundle",
     "bundle": "esbuild --format=esm --bundle --minify dist/index.js --outfile=dist/index.min.js --sourcemap && cp dist/index.d.ts dist/index.min.d.ts",


### PR DESCRIPTION
CI issue: gets rid of the minified main package import, which is causing issues in Node. Keeps it around in case anyone wants it, but doesn’t use it for the main export any more.