### PR TITLE
Add support for multiple schemas, YAML support

### DIFF
--- a/.changeset/fluffy-poets-melt.md
+++ b/.changeset/fluffy-poets-melt.md
@@ -1,0 +1,5 @@
+---
+'@cobalt-ui/cli': patch
+---
+
+Breaking: require Node v18 or greater

--- a/.changeset/ninety-readers-promise.md
+++ b/.changeset/ninety-readers-promise.md
@@ -1,0 +1,6 @@
+---
+'@cobalt-ui/core': minor
+'@cobalt-ui/cli': minor
+---
+
+Allow combining multiple schemas

--- a/.changeset/rude-eggs-nail.md
+++ b/.changeset/rude-eggs-nail.md
@@ -1,0 +1,6 @@
+---
+'@cobalt-ui/core': minor
+'@cobalt-ui/cli': minor
+---
+
+Allow loading tokens as YAML

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 20
       - uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 8
       - run: pnpm i
       - run: pnpm run lint
   test:
@@ -28,7 +28,7 @@ jobs:
           node-version: 20
       - uses: pnpm/action-setup@v2
         with:
-          version: latest
+          version: 8
       - run: pnpm i
       - run: pnpm run build
       - run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,13 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: latest
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20
+          version: 8
       - run: pnpm i
       - run: pnpm run build
       - uses: changesets/action@v1

--- a/docs/src/pages/docs/reference/config.md
+++ b/docs/src/pages/docs/reference/config.md
@@ -20,7 +20,29 @@ export default {
 };
 ```
 
-### Loading tokens from npm
+### Loading from YAML
+
+Cobalt supports `tokens.json` as YAML as well:
+
+```js
+export default {
+  tokens: './tokens.yaml',
+};
+```
+
+> ⚠️ Note the file must end in `.yml` or `.yaml` to take effect
+
+### Loading from URL
+
+Cobalt can load tokens from any **publicly-available** URL:
+
+```js
+export default {
+  tokens: 'https://my-bucket.s3.amazonaws.com/tokens.json',
+};
+```
+
+### Loading from npm
 
 To load tokens from an npm package, update `config.tokens` to point to the **full JSON path** (not merely the root package):
 
@@ -30,6 +52,20 @@ To load tokens from an npm package, update `config.tokens` to point to the **ful
 -   tokens: "@my-scope/my-tokens",             // ❌ Cobalt won’t be able to find the tokens
 +   tokens: "@my-scope/my-tokens/tokens.json", // ✅ Cobalt can locate this just fine
 ```
+
+### Loading multiple schemas
+
+Cobalt supports loading multiple tokens schemas by passing an array:
+
+```js
+export default {
+  tokens: ['./base.json', './theme.json', './overrides.json'],
+};
+```
+
+Cobalt will flatten these schemas in order, with the latter entries overriding the former if there are any conflicts. The final result of all the combined schemas **must** result in a valid tokens.json.
+
+> ⚠️ **Warning** All aliases must refer to the same document, e.g. don’t try to include filenames such as `{./theme.json#/color.action.50}`. Reference it as if it were in the same file.
 
 ## Token Type Options
 

--- a/examples/ibm/package.json
+++ b/examples/ibm/package.json
@@ -8,9 +8,9 @@
     "update": "node scripts/update"
   },
   "devDependencies": {
-    "@carbon/colors": "^11.6.0",
-    "@carbon/icons": "^11.10.0",
-    "@carbon/type": "^11.10.0",
+    "@carbon/colors": "^11.17.1",
+    "@carbon/icons": "^11.22.1",
+    "@carbon/type": "^11.20.1",
     "@cobalt-ui/cli": "workspace:*",
     "@cobalt-ui/plugin-css": "workspace:*",
     "@cobalt-ui/plugin-js": "workspace:*",

--- a/examples/salesforce/package.json
+++ b/examples/salesforce/package.json
@@ -12,8 +12,8 @@
     "@cobalt-ui/plugin-css": "workspace:*",
     "@cobalt-ui/plugin-js": "workspace:*",
     "@cobalt-ui/plugin-sass": "workspace:*",
-    "@salesforce-ux/design-system": "^2.16.2",
+    "@salesforce-ux/design-system": "^2.21.3",
     "better-color-tools": "^0.12.3",
-    "postcss": "^8.4.16"
+    "postcss": "^8.4.26"
   }
 }

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -9,10 +9,8 @@ import {parse} from '@cobalt-ui/core';
 import {DIM, FG_BLUE, FG_RED, FG_GREEN, FG_YELLOW, UNDERLINE, RESET} from '@cobalt-ui/utils';
 import chokidar from 'chokidar';
 import fs from 'node:fs';
-import path from 'node:path';
 import {performance} from 'node:perf_hooks';
 import yaml from 'js-yaml';
-import undici from 'undici';
 import {fileURLToPath, URL} from 'node:url';
 import parser from 'yargs-parser';
 import {init as initConfig} from '../dist/config.js';
@@ -210,11 +208,11 @@ async function loadTokens(tokenPaths) {
 
   // download/read
   for (const filepath of tokenPaths) {
-    const ext = path.extname(filepath.pathname);
-    const isYAMLExt = ext === '.yaml' || ext === '.yml';
+    const pathname = filepath.pathname.toLowerCase();
+    const isYAMLExt = pathname.endsWith('.yaml') || pathname.endsWith('.yml');
     if (filepath.protocol === 'url:') {
       try {
-        const raw = await undici.fetch(filepath, {method: 'GET', headers: {Accepted: '*/*', 'User-Agent': 'cobalt'}}).then((res) => res.text());
+        const raw = await globalThis.fetch(filepath, {method: 'GET', headers: {Accepted: '*/*', 'User-Agent': 'cobalt'}}).then((res) => res.text());
         if (isYAMLExt || res.headers.get('content-type').includes('yaml')) {
           rawTokens.push(yaml.load(raw));
         } else {

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -9,7 +9,10 @@ import {parse} from '@cobalt-ui/core';
 import {DIM, FG_BLUE, FG_RED, FG_GREEN, FG_YELLOW, UNDERLINE, RESET} from '@cobalt-ui/utils';
 import chokidar from 'chokidar';
 import fs from 'node:fs';
+import path from 'node:path';
 import {performance} from 'node:perf_hooks';
+import yaml from 'js-yaml';
+import undici from 'undici';
 import {fileURLToPath, URL} from 'node:url';
 import parser from 'yargs-parser';
 import {init as initConfig} from '../dist/config.js';
@@ -62,7 +65,13 @@ async function main() {
   }
   let config;
   try {
-    config = await loadConfig(resolveConfig(configPath));
+    // if running `co check [tokens]`, don’t load config from file
+    if (cmd === 'check' && args[0]) {
+      console.log(args[0]);
+      config = await initConfig({tokens: args[0]}, cwd);
+    } else {
+      config = await loadConfig(resolveConfig(configPath));
+    }
   } catch (err) {
     console.error(`  ${FG_RED}✘  ${err.message || err}${RESET}`);
     process.exit(1);
@@ -70,17 +79,12 @@ async function main() {
 
   switch (cmd) {
     case 'build': {
-      if (!fs.existsSync(config.tokens)) {
-        console.error(`  ${FG_RED}✘  Could not locate ${config.tokens}. To create one, run \`npx cobalt init\`.${RESET}`);
-        process.exit(1);
-      }
-
       if (!Array.isArray(config.plugins) || !config.plugins.length) {
         console.error(`  ${FG_RED}✘  No plugins defined! Add some in ${configPath || 'tokens.config.js'}${RESET}`);
         process.exit(1);
       }
 
-      let rawSchema = JSON.parse(fs.readFileSync(config.tokens), 'utf8');
+      let rawSchema = await loadTokens(config.tokens);
 
       const dt = new Intl.DateTimeFormat('en-us', {
         hour: '2-digit',
@@ -95,17 +99,16 @@ async function main() {
       if (result.errors) process.exit(1);
 
       if (watch) {
-        const tokenWatcher = chokidar.watch(fileURLToPath(config.tokens));
-        const tokensYAML = config.tokens.href.replace(cwd.href, '');
+        const tokenWatcher = chokidar.watch(config.tokens.map((filepath) => fileURLToPath(filepath)));
         tokenWatcher.on('change', async (filePath) => {
           try {
-            rawSchema = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+            rawSchema = await loadTokens(config.tokens);
             result = await build(rawSchema, config);
             if (result.errors || result.warnings) {
               printErrors(result.errors);
               printWarnings(result.warnings);
             } else {
-              console.log(`${DIM}${dt.format(new Date())}${RESET} ${FG_BLUE}Cobalt${RESET} ${FG_YELLOW}${tokensYAML}${RESET} updated ${FG_GREEN}✔${RESET}`);
+              console.log(`${DIM}${dt.format(new Date())}${RESET} ${FG_BLUE}Cobalt${RESET} ${FG_YELLOW}${filePath}${RESET} updated ${FG_GREEN}✔${RESET}`);
             }
           } catch (err) {
             printErrors([err.message || err]);
@@ -116,7 +119,7 @@ async function main() {
           try {
             console.log(`${DIM}${dt.format(new Date())}${RESET} ${FG_BLUE}Cobalt${RESET} ${FG_YELLOW}Config updated. Reloading…${RESET}`);
             config = await loadConfig(filePath);
-            rawSchema = JSON.parse(fs.readFileSync(config.tokens, 'utf8'));
+            rawSchema = await loadTokens(config.tokens);
             result = await build(rawSchema, config);
           } catch (err) {
             printErrors([err.message || err]);
@@ -136,22 +139,8 @@ async function main() {
       break;
     }
     case 'check': {
-      let tokensPath = config.tokens;
-      if (args[0]) {
-        tokensPath = new URL(args[0], cwd);
-        if (!fs.existsSync(tokensPath)) {
-          console.error(`Expected format: cobalt check ./path/to/tokens.json. Could not locate ${args[0]}.`);
-          process.exit(1);
-        }
-      }
-
-      if (!fs.existsSync(tokensPath)) {
-        console.error(`  ${FG_RED}✘  Could not locate ${tokensPath}. To create one, run \`npx cobalt init\`.${RESET}`);
-        process.exit(1);
-      }
-
-      let rawSchema = JSON.parse(fs.readFileSync(tokensPath, 'utf8'));
-      console.log(`${UNDERLINE}${fileURLToPath(tokensPath)}${RESET}`);
+      console.log(`${UNDERLINE}${fileURLToPath(config.tokens[0])}${RESET}`);
+      const rawSchema = await loadTokens(config.tokens);
       const {errors, warnings} = parse(rawSchema, config); // will throw if errors
       if (errors || warnings) {
         printErrors(errors);
@@ -213,6 +202,76 @@ async function loadConfig(configPath) {
   let userConfig = {};
   if (configPath) userConfig = (await import(configPath instanceof URL ? fileURLToPath(configPath) : configPath)).default;
   return await initConfig(userConfig, configPath instanceof URL ? configPath : `file://${process.cwd()}/`);
+}
+
+/** load tokens */
+async function loadTokens(tokenPaths) {
+  const rawTokens = [];
+
+  // download/read
+  for (const filepath of tokenPaths) {
+    const ext = path.extname(filepath.pathname);
+    const isYAMLExt = ext === '.yaml' || ext === '.yml';
+    if (filepath.protocol === 'url:') {
+      try {
+        const raw = await undici.fetch(filepath, {method: 'GET', headers: {Accepted: '*/*', 'User-Agent': 'cobalt'}}).then((res) => res.text());
+        if (isYAMLExt || res.headers.get('content-type').includes('yaml')) {
+          rawTokens.push(yaml.load(raw));
+        } else {
+          rawTokens.push(JSON.parse(raw));
+        }
+      } catch (err) {
+        console.error(`  ${FG_RED}✘  ${filepath.href}: ${err}${RESET}`);
+      }
+    } else {
+      if (fs.existsSync(filepath)) {
+        try {
+          const raw = fs.readFileSync(filepath, 'utf8');
+          if (isYAMLExt) {
+            rawTokens.push(yaml.load(raw));
+          } else {
+            rawTokens.push(JSON.parse(raw));
+          }
+        } catch (err) {
+          console.error(`  ${FG_RED}✘  ${filepath.href}: ${err}${RESET}`);
+        }
+      } else {
+        console.error(`  ${FG_RED}✘  Could not locate ${filepath}. To create one, run \`npx cobalt init\`.${RESET}`);
+        process.exit(1);
+      }
+    }
+  }
+
+  // combine
+  const tokens = {};
+  for (const subtokens of rawTokens) {
+    merge(tokens, subtokens);
+  }
+
+  return tokens;
+}
+
+/** Merge JSON B into A */
+function merge(a, b) {
+  if (Array.isArray(b)) {
+    console.error(`  ${FG_RED}✘ Internal error parsing tokens file.${RESET}`); // oops
+    process.exit(1);
+    return;
+  }
+  for (const [k, v] of Object.entries(b)) {
+    // overwrite if:
+    // - this key doesn’t exist on a, or
+    // - this is a token with a $value (don’t merge tokens! overwrite!), or
+    // - this is a primitive value (it’s the user’s responsibility to merge these correctly)
+    if (!(k in a) || Array.isArray(v) || typeof v !== 'object' || (typeof v === 'object' && '$value' in v)) {
+      a[k] = v;
+      continue;
+    }
+    // continue
+    if (typeof v === 'object' && !Array.isArray(v)) {
+      merge(a[k], v);
+    }
+  }
 }
 
 /** Print time elapsed */

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,7 +45,6 @@
     "js-yaml": "^4.1.0",
     "piscina": "^3.2.0",
     "svgo": "^3.0.2",
-    "undici": "^5.22.1",
     "yargs-parser": "^21.1.1"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,12 +42,15 @@
     "better-color-tools": "^0.12.3",
     "chokidar": "^3.5.3",
     "dotenv": "^16.3.1",
+    "js-yaml": "^4.1.0",
     "piscina": "^3.2.0",
     "svgo": "^3.0.2",
+    "undici": "^5.22.1",
     "yargs-parser": "^21.1.1"
   },
   "devDependencies": {
     "@types/node": "^20.4.2",
+    "execa": "^7.1.1",
     "figma-api": "^1.11.0",
     "npm-run-all": "^4.1.5",
     "vitest": "^0.33.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,9 @@
     "style tokens",
     "style system"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/drwpow/cobalt-ui.git",

--- a/packages/cli/test/build.test.js
+++ b/packages/cli/test/build.test.js
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import {execa} from 'execa';
+import {describe, expect, test} from 'vitest';
+
+const cmd = '../../../bin/cli.js';
+
+describe('co build', () => {
+  test('default', async () => {
+    const cwd = new URL('./fixtures/build-default/', import.meta.url);
+    await execa('node', [cmd, 'build'], {cwd});
+
+    const builtTokens = await import('./fixtures/build-default/tokens/index.js');
+
+    // rough token count
+    expect(Object.keys(builtTokens.meta).length).toBe(34);
+  });
+
+  test('yaml', async () => {
+    const cwd = new URL('./fixtures/build-yaml/', import.meta.url);
+    await execa('node', [cmd, 'build'], {cwd});
+
+    const builtTokens = await import('./fixtures/build-yaml/tokens/index.js');
+
+    // rough token count
+    expect(Object.keys(builtTokens.meta).length).toBe(34);
+  });
+
+  test('multiple', async () => {
+    const cwd = new URL('./fixtures/build-multiple/', import.meta.url);
+    await execa('node', [cmd, 'build'], {cwd});
+
+    const builtTokens = await import('./fixtures/build-multiple/tokens/index.js');
+
+    // rough token count
+    expect(Object.keys(builtTokens.meta).length).toBe(66);
+
+    // test 2: assert "color.black" in "typography.json" took priority
+    expect(builtTokens.meta['color.black']._original).toEqual({
+      $value: '#081f2f',
+    });
+  });
+});

--- a/packages/cli/test/check.test.js
+++ b/packages/cli/test/check.test.js
@@ -17,6 +17,11 @@ describe('co check', () => {
     expect(result.exitCode).toBe(0);
   });
 
+  test('URL', async () => {
+    const result = await execa('node', ['./bin/cli.js', 'check', 'https://raw.githubusercontent.com/drwpow/cobalt-ui/main/packages/cli/test/fixtures/check-default/tokens.json']);
+    expect(result.exitCode).toBe(0);
+  });
+
   test('invalid tokens', async () => {
     const cwd = new URL('./fixtures/check-invalid/', import.meta.url);
     await expect(async () => await execa('node', [cmd, 'check'], {cwd, throwOnStderr: false})).rejects.toThrow();

--- a/packages/cli/test/check.test.js
+++ b/packages/cli/test/check.test.js
@@ -1,22 +1,24 @@
-import {execSync} from 'child_process';
+import {execa} from 'execa';
 import {URL} from 'node:url';
 import {describe, expect, test} from 'vitest';
 
-const cmd = 'node ../../../bin/cli.js';
+const cmd = '../../../bin/cli.js';
 
 describe('co check', () => {
-  test('default filename', () => {
+  test('default filename', async () => {
     const cwd = new URL('./fixtures/check-default/', import.meta.url);
-    expect(() => execSync(`${cmd} check`, {cwd})).to.not.throw();
+    const result = await execa('node', [cmd, 'check'], {cwd});
+    expect(result.exitCode).toBe(0);
   });
 
-  test('custom filename', () => {
+  test('custom filename', async () => {
     const cwd = new URL('./fixtures/check-custom/', import.meta.url);
-    expect(() => execSync(`${cmd} check tokens-2.json`, {cwd})).to.not.throw();
+    const result = await execa('node', [cmd, 'check', 'tokens-2.json'], {cwd});
+    expect(result.exitCode).toBe(0);
   });
 
-  test('invalid tokens', () => {
+  test('invalid tokens', async () => {
     const cwd = new URL('./fixtures/check-invalid/', import.meta.url);
-    expect(() => execSync(`${cmd} check`, {cwd})).to.throw();
+    await expect(async () => await execa('node', [cmd, 'check'], {cwd, throwOnStderr: false})).rejects.toThrow();
   });
 });

--- a/packages/cli/test/fixtures/build-default/tokens.config.js
+++ b/packages/cli/test/fixtures/build-default/tokens.config.js
@@ -1,0 +1,5 @@
+import pluginJs from '../../../../plugin-js/dist/index.js';
+
+export default {
+  plugins: [pluginJs()],
+};

--- a/packages/cli/test/fixtures/build-default/tokens.json
+++ b/packages/cli/test/fixtures/build-default/tokens.json
@@ -1,0 +1,47 @@
+{
+  "color": {
+    "$type": "color",
+    "black": {
+      "$type": "color",
+      "$description": "This will get overridden in typography.json (on purpose)",
+      "$value": "#00193f"
+    },
+    "blue": {
+      "10": {"$value": "oklch(10% 0.069574 264)"},
+      "15": {"$value": "oklch(15% 0.102086 265)"},
+      "20": {"$value": "oklch(20% 0.000304 265)"},
+      "25": {"$value": "oklch(25% 0.172216 265)"},
+      "30": {"$value": "oklch(30% 0.203543 266)"},
+      "40": {"$value": "oklch(40% 0.216254 267)"},
+      "50": {"$value": "oklch(50% 0.216583 268)"},
+      "60": {"$value": "oklch(60% 0.216564 269)"},
+      "70": {"$value": "oklch(70% 0.156718 268)"},
+      "80": {"$value": "oklch(80% 0.10054 267)"},
+      "85": {"$value": "oklch(85% 0.073053 266)"},
+      "90": {"$value": "oklch(90% 0.048514 265)"},
+      "95": {"$value": "oklch(95% 0.023788 264)"}
+    },
+    "gray": {
+      "0": {"$value": "{color.black}"},
+      "10": {"$value": "#00040d"},
+      "15": {"$value": "#040d18"},
+      "20": {"$value": "#0e1823"},
+      "25": {"$value": "#1a232f"},
+      "30": {"$value": "#262f3c"},
+      "40": {"$value": "#414956"},
+      "50": {"$value": "#5d6471"},
+      "60": {"$value": "#7a808d"},
+      "70": {"$value": "#999eaa"},
+      "80": {"$value": "#b9bec8"},
+      "85": {"$value": "#c9ced8"},
+      "90": {"$value": "#dadee7"},
+      "95": {"$value": "#ebeef7"},
+      "100": {"$value": "{color.white}"}
+    },
+    "darkGray": {"$value": "#282a37"},
+    "green": {"$value": "#77cd8f"},
+    "purple": {"$value": "#6a35d9"},
+    "red": {"$value": "#f6566a"},
+    "white": {"$value": "#ffffff"}
+  }
+}

--- a/packages/cli/test/fixtures/build-multiple/base.json
+++ b/packages/cli/test/fixtures/build-multiple/base.json
@@ -1,0 +1,47 @@
+{
+  "color": {
+    "$type": "color",
+    "black": {
+      "$type": "color",
+      "$description": "This will get overridden in typography.json (on purpose)",
+      "$value": "#00193f"
+    },
+    "blue": {
+      "10": {"$value": "oklch(10% 0.069574 264)"},
+      "15": {"$value": "oklch(15% 0.102086 265)"},
+      "20": {"$value": "oklch(20% 0.000304 265)"},
+      "25": {"$value": "oklch(25% 0.172216 265)"},
+      "30": {"$value": "oklch(30% 0.203543 266)"},
+      "40": {"$value": "oklch(40% 0.216254 267)"},
+      "50": {"$value": "oklch(50% 0.216583 268)"},
+      "60": {"$value": "oklch(60% 0.216564 269)"},
+      "70": {"$value": "oklch(70% 0.156718 268)"},
+      "80": {"$value": "oklch(80% 0.10054 267)"},
+      "85": {"$value": "oklch(85% 0.073053 266)"},
+      "90": {"$value": "oklch(90% 0.048514 265)"},
+      "95": {"$value": "oklch(95% 0.023788 264)"}
+    },
+    "gray": {
+      "0": {"$value": "{color.black}"},
+      "10": {"$value": "#00040d"},
+      "15": {"$value": "#040d18"},
+      "20": {"$value": "#0e1823"},
+      "25": {"$value": "#1a232f"},
+      "30": {"$value": "#262f3c"},
+      "40": {"$value": "#414956"},
+      "50": {"$value": "#5d6471"},
+      "60": {"$value": "#7a808d"},
+      "70": {"$value": "#999eaa"},
+      "80": {"$value": "#b9bec8"},
+      "85": {"$value": "#c9ced8"},
+      "90": {"$value": "#dadee7"},
+      "95": {"$value": "#ebeef7"},
+      "100": {"$value": "{color.white}"}
+    },
+    "darkGray": {"$value": "#282a37"},
+    "green": {"$value": "#77cd8f"},
+    "purple": {"$value": "#6a35d9"},
+    "red": {"$value": "#f6566a"},
+    "white": {"$value": "#ffffff"}
+  }
+}

--- a/packages/cli/test/fixtures/build-multiple/semantic.json
+++ b/packages/cli/test/fixtures/build-multiple/semantic.json
@@ -1,0 +1,39 @@
+{
+  "color": {
+    "$type": "color",
+    "ui": {
+      "contrast": {
+        "0": {"$value": "{color.gray.100}", "$extensions": {"mode": {"light": "{color.gray.100}", "dark": "{color.gray.0}"}}},
+        "05": {"$value": "{color.gray.95}", "$extensions": {"mode": {"light": "{color.gray.95}", "dark": "{color.gray.10}"}}},
+        "10": {"$value": "{color.gray.90}", "$extensions": {"mode": {"light": "{color.gray.90}", "dark": "{color.gray.10}"}}},
+        "15": {"$value": "{color.gray.85}", "$extensions": {"mode": {"light": "{color.gray.85}", "dark": "{color.gray.15}"}}},
+        "20": {"$value": "{color.gray.80}", "$extensions": {"mode": {"light": "{color.gray.80}", "dark": "{color.gray.20}"}}},
+        "30": {"$value": "{color.gray.70}", "$extensions": {"mode": {"light": "{color.gray.70}", "dark": "{color.gray.30}"}}},
+        "40": {"$value": "{color.gray.60}", "$extensions": {"mode": {"light": "{color.gray.60}", "dark": "{color.gray.40}"}}},
+        "50": {"$value": "{color.gray.50}", "$extensions": {"mode": {"light": "{color.gray.50}", "dark": "{color.gray.50}"}}},
+        "60": {"$value": "{color.gray.40}", "$extensions": {"mode": {"light": "{color.gray.40}", "dark": "{color.gray.60}"}}},
+        "70": {"$value": "{color.gray.30}", "$extensions": {"mode": {"light": "{color.gray.30}", "dark": "{color.gray.70}"}}},
+        "80": {"$value": "{color.gray.20}", "$extensions": {"mode": {"light": "{color.gray.20}", "dark": "{color.gray.80}"}}},
+        "85": {"$value": "{color.gray.15}", "$extensions": {"mode": {"light": "{color.gray.15}", "dark": "{color.gray.85}"}}},
+        "90": {"$value": "{color.gray.10}", "$extensions": {"mode": {"light": "{color.gray.10}", "dark": "{color.gray.90}"}}},
+        "95": {"$value": "{color.gray.10}", "$extensions": {"mode": {"light": "{color.gray.10}", "dark": "{color.gray.95}"}}},
+        "100": {"$value": "{color.gray.0}", "$extensions": {"mode": {"light": "{color.gray.0}", "dark": "{color.gray.100}"}}}
+      },
+      "action": {
+        "10": {"$value": "{color.blue.10}"},
+        "15": {"$value": "{color.blue.15}"},
+        "20": {"$value": "{color.blue.20}"},
+        "25": {"$value": "{color.blue.25}"},
+        "30": {"$value": "{color.blue.30}"},
+        "40": {"$value": "{color.blue.40}"},
+        "50": {"$value": "{color.blue.50}"},
+        "60": {"$value": "{color.blue.60}"},
+        "70": {"$value": "{color.blue.70}"},
+        "80": {"$value": "{color.blue.80}"},
+        "85": {"$value": "{color.blue.85}"},
+        "90": {"$value": "{color.blue.90}"},
+        "95": {"$value": "{color.blue.95}"}
+      }
+    }
+  }
+}

--- a/packages/cli/test/fixtures/build-multiple/tokens.config.js
+++ b/packages/cli/test/fixtures/build-multiple/tokens.config.js
@@ -1,0 +1,6 @@
+import pluginJs from '../../../../plugin-js/dist/index.js';
+
+export default {
+  tokens: ['base.json', 'semantic.json', 'typography.json'],
+  plugins: [pluginJs()],
+};

--- a/packages/cli/test/fixtures/build-multiple/typography.json
+++ b/packages/cli/test/fixtures/build-multiple/typography.json
@@ -1,0 +1,29 @@
+{
+  "color": {
+    "$type": "color",
+    "black": {
+      "$value": "#081f2f"
+    }
+  },
+  "typography": {
+    "$type": "typography",
+    "family": {
+      "base": {"$type": "fontName", "$value": ["system-ui", "sans-serif"]},
+      "mono": {"$type": "fontName", "$value": ["ui-monospace", "monospace"]}
+    },
+    "base": {
+      "$value": {
+        "fontFamily": "{typography.family.base}",
+        "fontSize": "0.875rem",
+        "lineHeight": "1.2"
+      }
+    },
+    "code": {
+      "$value": {
+        "fontFamily": "{typography.family.mono}",
+        "fontSize": "0.875rem",
+        "lineHeight": "1.5"
+      }
+    }
+  }
+}

--- a/packages/cli/test/fixtures/build-yaml/tokens.config.js
+++ b/packages/cli/test/fixtures/build-yaml/tokens.config.js
@@ -1,0 +1,6 @@
+import pluginJs from '../../../../plugin-js/dist/index.js';
+
+export default {
+  tokens: './tokens.yaml',
+  plugins: [pluginJs()],
+};

--- a/packages/cli/test/fixtures/build-yaml/tokens.yaml
+++ b/packages/cli/test/fixtures/build-yaml/tokens.yaml
@@ -1,0 +1,74 @@
+color:
+  $type: color
+  black:
+    $type: color
+    $description: This will get overridden in typography.json (on purpose)
+    $value: '#00193f'
+  blue:
+    10:
+      $value: 'oklch(10% 0.069574 264)'
+    15:
+      $value: 'oklch(15% 0.102086 265)'
+    20:
+      $value: 'oklch(20% 0.000304 265)'
+    25:
+      $value: 'oklch(25% 0.172216 265)'
+    30:
+      $value: 'oklch(30% 0.203543 266)'
+    40:
+      $value: 'oklch(40% 0.216254 267)'
+    50:
+      $value: 'oklch(50% 0.216583 268)'
+    60:
+      $value: 'oklch(60% 0.216564 269)'
+    70:
+      $value: 'oklch(70% 0.156718 268)'
+    80:
+      $value: 'oklch(80% 0.10054 267)'
+    85:
+      $value: 'oklch(85% 0.073053 266)'
+    90:
+      $value: 'oklch(90% 0.048514 265)'
+    95:
+      $value: 'oklch(95% 0.023788 264)'
+  'gray':
+    0:
+      $value: '{color.black}'
+    10:
+      $value: '#00040d'
+    15:
+      $value: '#040d18'
+    20:
+      $value: '#0e1823'
+    25:
+      $value: '#1a232f'
+    30:
+      $value: '#262f3c'
+    40:
+      $value: '#414956'
+    50:
+      $value: '#5d6471'
+    60:
+      $value: '#7a808d'
+    70:
+      $value: '#999eaa'
+    80:
+      $value: '#b9bec8'
+    85:
+      $value: '#c9ced8'
+    90:
+      $value: '#dadee7'
+    95:
+      $value: '#ebeef7'
+    100:
+      $value: '{color.white}'
+  darkGray:
+    $value: '#282a37'
+  green:
+    $value: '#77cd8f'
+  purple:
+    $value: '#6a35d9'
+  red:
+    $value: '#f6566a'
+  white:
+    $value: '#ffffff'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,7 +52,7 @@ export interface BuildResult {
 }
 
 export interface ResolvedConfig extends ParseOptions {
-  tokens: URL;
+  tokens: URL[];
   outDir: URL;
   plugins: Plugin[];
 }
@@ -67,7 +67,7 @@ export interface Plugin {
 
 export interface Config extends Partial<ParseOptions> {
   /** path to tokens.json (default: "./tokens.json") */
-  tokens?: string;
+  tokens?: string | string[];
   /** output directory (default: "./tokens/") */
   outDir?: string;
   /** specify plugins */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,9 +212,6 @@ importers:
       svgo:
         specifier: ^3.0.2
         version: 3.0.2
-      undici:
-        specifier: ^5.22.1
-        version: 5.22.1
       yargs-parser:
         specifier: ^21.1.1
         version: 21.1.1
@@ -2154,6 +2151,7 @@ packages:
     engines: {node: '>=10.16.0'}
     dependencies:
       streamsearch: 1.1.0
+    dev: true
 
   /cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -5576,6 +5574,7 @@ packages:
   /streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+    dev: true
 
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -5943,6 +5942,7 @@ packages:
     engines: {node: '>=14.0'}
     dependencies:
       busboy: 1.6.0
+    dev: true
 
   /unherit@3.0.1:
     resolution: {integrity: sha512-akOOQ/Yln8a2sgcLj4U0Jmx0R5jpIg2IUyRrWOzmEbjBtGzBdHtSeFKgoEcoH4KYIG/Pb8GQ/BwtYm0GCq1Sqg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,14 +126,14 @@ importers:
   examples/ibm:
     devDependencies:
       '@carbon/colors':
-        specifier: ^11.6.0
-        version: 11.6.0
+        specifier: ^11.17.1
+        version: 11.17.1
       '@carbon/icons':
-        specifier: ^11.10.0
-        version: 11.10.0
+        specifier: ^11.22.1
+        version: 11.22.1
       '@carbon/type':
-        specifier: ^11.10.0
-        version: 11.10.0
+        specifier: ^11.20.1
+        version: 11.20.1
       '@cobalt-ui/cli':
         specifier: workspace:*
         version: link:../../packages/cli
@@ -162,14 +162,14 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sass
       '@salesforce-ux/design-system':
-        specifier: ^2.16.2
-        version: 2.16.2(postcss@8.4.18)
+        specifier: ^2.21.3
+        version: 2.21.3(postcss@8.4.26)
       better-color-tools:
         specifier: ^0.12.3
         version: 0.12.3
       postcss:
-        specifier: ^8.4.16
-        version: 8.4.18
+        specifier: ^8.4.26
+        version: 8.4.26
 
   examples/shopify:
     devDependencies:
@@ -687,29 +687,29 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
-  /@carbon/colors@11.6.0:
-    resolution: {integrity: sha512-LE3aaQvRVR9zI2ao4+SHP8vfEaXtfffq4wXHvbPwoTK+I3Db745XuNWeWxC3Rte2uNPS9sjeEyCid2Q0wY/tSw==}
+  /@carbon/colors@11.17.1:
+    resolution: {integrity: sha512-Q2VlMaZcl3U9Qc1RQbhuf4M4SVuJIeE+NIIDExPCRFaWeuN/5EIUYxEkPgDqvkLU91QTu6lH8TqxFPZORlRvDA==}
     dev: true
 
-  /@carbon/grid@11.7.0:
-    resolution: {integrity: sha512-OCDXQNSPVOoBQN08Qn5wo2WpKRGRm/kEBo6ZTl2NoDCl21mcYJZ0IDbKPTukixJB1sUNDUlnrpwMoaznPj48dw==}
+  /@carbon/grid@11.16.1:
+    resolution: {integrity: sha512-xrnySc/9jRebcVyATn6ArO9kQsgUcUDwrUrWPH5yt4AU7lDvzfpsxbO5NehRekURxPJjplr0DOhPAwC4qbuaaw==}
     dependencies:
-      '@carbon/layout': 11.7.0
+      '@carbon/layout': 11.16.1
     dev: true
 
-  /@carbon/icons@11.10.0:
-    resolution: {integrity: sha512-NUKXGZ5Yi184mvAs9q1sPt0ns2qXOF6dK4DG4mMHq5RgJRjq5diLHIm1t49SIwjF4X8b3KSehmrK7N9H6bf1Zg==}
+  /@carbon/icons@11.22.1:
+    resolution: {integrity: sha512-d1FtLT3+BRuUn6P59mvIr6m4osfz7RQbKL8tSrU72c45/eb/w8xDJ/1NOSoVIjZ55/JKLo9XkSt7HwwOJBlEiQ==}
     dev: true
 
-  /@carbon/layout@11.7.0:
-    resolution: {integrity: sha512-p4YQvW8U5Go0Tz1PZZgllGSPmoq8xBB5PHByuHiAjzwGclxPsBmY6Ea7tftINFW8VlcjDcampyT8VfZXhP2lFg==}
+  /@carbon/layout@11.16.1:
+    resolution: {integrity: sha512-uUJmNrB7GKJzR/ZEzVxqGNb7US8UB1jL0X3lia3pnyqQ8Rcxq3y1RNmj/bfuI6LWC9GA0lLrsKRdKOpdLyqJMQ==}
     dev: true
 
-  /@carbon/type@11.10.0:
-    resolution: {integrity: sha512-LjhhJchI0Vpnmq2IkNtHy7HIW/WjiOEVXH+bDKf0Laay0EQtwxagQSI41W2+0dNtcK4zJBKjfm1uorsxmR5/Qw==}
+  /@carbon/type@11.20.1:
+    resolution: {integrity: sha512-CZSDN//3M7DhiMEzwNjDXpJ3Iqcaetu/hiFghxSACOuz88jni36Qj/qOg0ELZNrsswGk5GwnJx/IN1u40TAieA==}
     dependencies:
-      '@carbon/grid': 11.7.0
-      '@carbon/layout': 11.7.0
+      '@carbon/grid': 11.16.1
+      '@carbon/layout': 11.16.1
     dev: true
 
   /@changesets/apply-release-plan@6.1.4:
@@ -1488,12 +1488,12 @@ packages:
     resolution: {integrity: sha512-ZHHfwB0z0z6nDJp263gyGIClYDy+rl0nwqyi4qhcv3Cxhkmtf+If2KVjr6FQqBBFfi1wQwUzaax2FBvfEMFBnw==}
     dev: true
 
-  /@salesforce-ux/design-system@2.16.2(postcss@8.4.18):
-    resolution: {integrity: sha512-8qG5wdR3+5s4zcszMZs9Z4HocPV6uWhisHSeUyxl6Idb5m99yER3HwyKtyIUViPB/8ukDwptLBvJWH+qwA6EOg==}
+  /@salesforce-ux/design-system@2.21.3(postcss@8.4.26):
+    resolution: {integrity: sha512-7+3LWTH26O0y/Uxw9bg6F+TntS4tXB7gmD8a3bLFwAxUgsdO7LVbKvchwFHElgZQU5ICFfUCFB8LzmCgVJ9KIA==}
     peerDependencies:
       postcss: ^8.3.5
     dependencies:
-      postcss: 8.4.18
+      postcss: 8.4.26
     dev: true
 
   /@sinclair/typebox@0.27.8:
@@ -4570,12 +4570,6 @@ packages:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
 
-  /nanoid@3.3.4:
-    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-    dev: true
-
   /nanoid@3.3.6:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -4985,15 +4979,6 @@ packages:
       jsonc-parser: 3.2.0
       mlly: 1.3.0
       pathe: 1.1.1
-    dev: true
-
-  /postcss@8.4.18:
-    resolution: {integrity: sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==}
-    engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.4
-      picocolors: 1.0.0
-      source-map-js: 1.0.2
     dev: true
 
   /postcss@8.4.26:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,12 +203,18 @@ importers:
       dotenv:
         specifier: ^16.3.1
         version: 16.3.1
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       piscina:
         specifier: ^3.2.0
         version: 3.2.0
       svgo:
         specifier: ^3.0.2
         version: 3.0.2
+      undici:
+        specifier: ^5.22.1
+        version: 5.22.1
       yargs-parser:
         specifier: ^21.1.1
         version: 21.1.1
@@ -216,6 +222,9 @@ importers:
       '@types/node':
         specifier: ^20.4.2
         version: 20.4.2
+      execa:
+        specifier: ^7.1.1
+        version: 7.1.1
       figma-api:
         specifier: ^1.11.0
         version: 1.11.0
@@ -1907,7 +1916,6 @@ packages:
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-    dev: true
 
   /array-buffer-byte-length@1.0.0:
     resolution: {integrity: sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==}
@@ -2146,7 +2154,6 @@ packages:
     engines: {node: '>=10.16.0'}
     dependencies:
       streamsearch: 1.1.0
-    dev: true
 
   /cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -3870,7 +3877,6 @@ packages:
     hasBin: true
     dependencies:
       argparse: 2.0.1
-    dev: true
 
   /jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
@@ -5585,7 +5591,6 @@ packages:
   /streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
-    dev: true
 
   /string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -5953,7 +5958,6 @@ packages:
     engines: {node: '>=14.0'}
     dependencies:
       busboy: 1.6.0
-    dev: true
 
   /unherit@3.0.1:
     resolution: {integrity: sha512-akOOQ/Yln8a2sgcLj4U0Jmx0R5jpIg2IUyRrWOzmEbjBtGzBdHtSeFKgoEcoH4KYIG/Pb8GQ/BwtYm0GCq1Sqg==}


### PR DESCRIPTION
## Changes

- Adds support for multiple schemas (#27)
- Adds YAML support because why not

⚠️ **Warning**: this is more “concatenation,” not true multi-schemas as outlined in https://github.com/design-tokens/community-group/issues/166. So this doesn’t make remote aliasing possible. But it does allow your tokens files to be split up & distributed.

