### PR TITLE
Don’t auto-bump deps

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,6 +4,5 @@
   "commit": false,
   "linked": [["@cobalt-ui/core", "@cobalt-ui/cli"]],
   "access": "public",
-  "baseBranch": "main",
-  "updateInternalDependencies": "patch"
+  "baseBranch": "main"
 }


### PR DESCRIPTION
Changesets is just going ham and keeps trying to release major versions every time the `core` or `cli` packages get an update. Seems to be an open bug with changesets: https://github.com/changesets/changesets/issues/960

Until that’s resolved, just disable (and be sure to manually bump if needed)