### PR TITLE
Add `co bundle` command

### DIFF
--- a/.changeset/rich-poets-act.md
+++ b/.changeset/rich-poets-act.md
@@ -1,0 +1,5 @@
+---
+'@cobalt-ui/cli': patch
+---
+
+Minor console output improvements

--- a/.changeset/rotten-shoes-hang.md
+++ b/.changeset/rotten-shoes-hang.md
@@ -1,0 +1,6 @@
+---
+'@cobalt-ui/cli': minor
+'@cobalt-ui/core': minor
+---
+
+Add `co bundle` command

--- a/docs/src/pages/docs/reference/cli.md
+++ b/docs/src/pages/docs/reference/cli.md
@@ -5,7 +5,7 @@ layout: ../../../layouts/docs.astro
 
 # CLI
 
-The Cobalt CLI is available via npm:
+The Cobalt CLI is available for installing via npm:
 
 ```bash
 npm i -D @cobalt-ui/cli
@@ -13,10 +13,13 @@ npm i -D @cobalt-ui/cli
 
 ## API
 
+All CLI commands require a [config](/docs/reference/config/) to work properly, with the exception of `co check`.
+
 `npx co [command]`
 
-| Command        | Notes                                                                                                                            |
-| :------------- | :------------------------------------------------------------------------------------------------------------------------------- |
-| `build`        | Turn design tokens into output files using [plugins](/docs/plugins). You can watch for changes in dev mode with `build --watch`. |
-| `check [path]` | Validate a `tokens.json` file and check for errors. This won’t output any files.                                                 |
-| `init`         | Create a starter `tokens.json` file.                                                                                             |
+| Command        | Notes                                                                                                                                                                                                                                           |
+| :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `build`        | Turn design tokens into output files using [plugins](/docs/plugins). You can watch for changes in dev mode with `build --watch`.                                                                                                                |
+| `bundle`       | Bundle multiple `tokens.json` files into one, e.g. `co bundle --out path/to/output.json`. Can output `.json` or `.yaml`. Requires [multiple schemas set in config](https://cobalt-ui.pages.dev/docs/reference/config/#loading-multiple-schemas) |
+| `check [path]` | Validate a `tokens.json` file and check for errors. This won’t output any files.                                                                                                                                                                |
+| `init`         | Create a starter `tokens.json` file.                                                                                                                                                                                                            |

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@typescript-eslint/parser": "^6.2.0",
     "del-cli": "^4.0.1",
     "eslint": "^8.45.0",
-    "eslint-config-prettier": "^8.8.0",
+    "eslint-config-prettier": "^8.9.0",
     "eslint-plugin-prettier": "^4.2.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.8",

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,1 +1,2 @@
 **/tokens/**/*
+test/fixtures/bundle-default/given

--- a/packages/cli/test/build.test.js
+++ b/packages/cli/test/build.test.js
@@ -1,11 +1,10 @@
-import fs from 'node:fs';
 import {execa} from 'execa';
-import {describe, expect, test} from 'vitest';
+import {describe, expect, it} from 'vitest';
 
 const cmd = '../../../bin/cli.js';
 
 describe('co build', () => {
-  test('default', async () => {
+  it('default', async () => {
     const cwd = new URL('./fixtures/build-default/', import.meta.url);
     await execa('node', [cmd, 'build'], {cwd});
 
@@ -15,7 +14,7 @@ describe('co build', () => {
     expect(Object.keys(builtTokens.meta).length).toBe(34);
   });
 
-  test('yaml', async () => {
+  it('yaml', async () => {
     const cwd = new URL('./fixtures/build-yaml/', import.meta.url);
     await execa('node', [cmd, 'build'], {cwd});
 
@@ -25,7 +24,7 @@ describe('co build', () => {
     expect(Object.keys(builtTokens.meta).length).toBe(34);
   });
 
-  test('multiple', async () => {
+  it('multiple', async () => {
     const cwd = new URL('./fixtures/build-multiple/', import.meta.url);
     await execa('node', [cmd, 'build'], {cwd});
 

--- a/packages/cli/test/bundle.test.js
+++ b/packages/cli/test/bundle.test.js
@@ -1,0 +1,20 @@
+import {execa} from 'execa';
+import fs from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import {describe, expect, it} from 'vitest';
+
+const cmd = '../../../bin/cli.js';
+
+describe('co bundle', () => {
+  it('JSON', async () => {
+    const cwd = new URL('./fixtures/bundle-default/', import.meta.url);
+    await execa('node', [cmd, 'bundle', '--out', 'given/bundled.json'], {cwd});
+    expect(fs.readFileSync(new URL('./given/bundled.json', cwd), 'utf8')).toMatchFileSnapshot(fileURLToPath(new URL('./want/bundled.json', cwd)));
+  });
+
+  it('YAML', async () => {
+    const cwd = new URL('./fixtures/bundle-default/', import.meta.url);
+    await execa('node', [cmd, 'bundle', '--out', 'given/bundled.yaml'], {cwd});
+    expect(fs.readFileSync(new URL('./given/bundled.yaml', cwd), 'utf8')).toMatchFileSnapshot(fileURLToPath(new URL('./want/bundled.yaml', cwd)));
+  });
+});

--- a/packages/cli/test/check.test.js
+++ b/packages/cli/test/check.test.js
@@ -1,28 +1,28 @@
 import {execa} from 'execa';
 import {URL} from 'node:url';
-import {describe, expect, test} from 'vitest';
+import {describe, expect, it} from 'vitest';
 
 const cmd = '../../../bin/cli.js';
 
 describe('co check', () => {
-  test('default filename', async () => {
+  it('default filename', async () => {
     const cwd = new URL('./fixtures/check-default/', import.meta.url);
     const result = await execa('node', [cmd, 'check'], {cwd});
     expect(result.exitCode).toBe(0);
   });
 
-  test('custom filename', async () => {
+  it('custom filename', async () => {
     const cwd = new URL('./fixtures/check-custom/', import.meta.url);
     const result = await execa('node', [cmd, 'check', 'tokens-2.json'], {cwd});
     expect(result.exitCode).toBe(0);
   });
 
-  test('URL', async () => {
-    const result = await execa('node', ['./bin/cli.js', 'check', 'https://raw.githubusercontent.com/drwpow/cobalt-ui/main/packages/cli/test/fixtures/check-default/tokens.json']);
+  it('URL', async () => {
+    const result = await execa('node', ['./bin/cli.js', 'check', 'https://raw.githubusercontent.com/drwpow/cobalt-ui/main/packages/cli/it/fixtures/check-default/tokens.json']);
     expect(result.exitCode).toBe(0);
   });
 
-  test('invalid tokens', async () => {
+  it('invalid tokens', async () => {
     const cwd = new URL('./fixtures/check-invalid/', import.meta.url);
     await expect(async () => await execa('node', [cmd, 'check'], {cwd, throwOnStderr: false})).rejects.toThrow();
   });

--- a/packages/cli/test/fixtures/bundle-default/base.json
+++ b/packages/cli/test/fixtures/bundle-default/base.json
@@ -1,0 +1,47 @@
+{
+  "color": {
+    "$type": "color",
+    "black": {
+      "$type": "color",
+      "$description": "This will get overridden in typography.json (on purpose)",
+      "$value": "#00193f"
+    },
+    "blue": {
+      "10": {"$value": "oklch(10% 0.069574 264)"},
+      "15": {"$value": "oklch(15% 0.102086 265)"},
+      "20": {"$value": "oklch(20% 0.000304 265)"},
+      "25": {"$value": "oklch(25% 0.172216 265)"},
+      "30": {"$value": "oklch(30% 0.203543 266)"},
+      "40": {"$value": "oklch(40% 0.216254 267)"},
+      "50": {"$value": "oklch(50% 0.216583 268)"},
+      "60": {"$value": "oklch(60% 0.216564 269)"},
+      "70": {"$value": "oklch(70% 0.156718 268)"},
+      "80": {"$value": "oklch(80% 0.10054 267)"},
+      "85": {"$value": "oklch(85% 0.073053 266)"},
+      "90": {"$value": "oklch(90% 0.048514 265)"},
+      "95": {"$value": "oklch(95% 0.023788 264)"}
+    },
+    "gray": {
+      "0": {"$value": "{color.black}"},
+      "10": {"$value": "#00040d"},
+      "15": {"$value": "#040d18"},
+      "20": {"$value": "#0e1823"},
+      "25": {"$value": "#1a232f"},
+      "30": {"$value": "#262f3c"},
+      "40": {"$value": "#414956"},
+      "50": {"$value": "#5d6471"},
+      "60": {"$value": "#7a808d"},
+      "70": {"$value": "#999eaa"},
+      "80": {"$value": "#b9bec8"},
+      "85": {"$value": "#c9ced8"},
+      "90": {"$value": "#dadee7"},
+      "95": {"$value": "#ebeef7"},
+      "100": {"$value": "{color.white}"}
+    },
+    "darkGray": {"$value": "#282a37"},
+    "green": {"$value": "#77cd8f"},
+    "purple": {"$value": "#6a35d9"},
+    "red": {"$value": "#f6566a"},
+    "white": {"$value": "#ffffff"}
+  }
+}

--- a/packages/cli/test/fixtures/bundle-default/semantic.json
+++ b/packages/cli/test/fixtures/bundle-default/semantic.json
@@ -1,0 +1,39 @@
+{
+  "color": {
+    "$type": "color",
+    "ui": {
+      "contrast": {
+        "0": {"$value": "{color.gray.100}", "$extensions": {"mode": {"light": "{color.gray.100}", "dark": "{color.gray.0}"}}},
+        "05": {"$value": "{color.gray.95}", "$extensions": {"mode": {"light": "{color.gray.95}", "dark": "{color.gray.10}"}}},
+        "10": {"$value": "{color.gray.90}", "$extensions": {"mode": {"light": "{color.gray.90}", "dark": "{color.gray.10}"}}},
+        "15": {"$value": "{color.gray.85}", "$extensions": {"mode": {"light": "{color.gray.85}", "dark": "{color.gray.15}"}}},
+        "20": {"$value": "{color.gray.80}", "$extensions": {"mode": {"light": "{color.gray.80}", "dark": "{color.gray.20}"}}},
+        "30": {"$value": "{color.gray.70}", "$extensions": {"mode": {"light": "{color.gray.70}", "dark": "{color.gray.30}"}}},
+        "40": {"$value": "{color.gray.60}", "$extensions": {"mode": {"light": "{color.gray.60}", "dark": "{color.gray.40}"}}},
+        "50": {"$value": "{color.gray.50}", "$extensions": {"mode": {"light": "{color.gray.50}", "dark": "{color.gray.50}"}}},
+        "60": {"$value": "{color.gray.40}", "$extensions": {"mode": {"light": "{color.gray.40}", "dark": "{color.gray.60}"}}},
+        "70": {"$value": "{color.gray.30}", "$extensions": {"mode": {"light": "{color.gray.30}", "dark": "{color.gray.70}"}}},
+        "80": {"$value": "{color.gray.20}", "$extensions": {"mode": {"light": "{color.gray.20}", "dark": "{color.gray.80}"}}},
+        "85": {"$value": "{color.gray.15}", "$extensions": {"mode": {"light": "{color.gray.15}", "dark": "{color.gray.85}"}}},
+        "90": {"$value": "{color.gray.10}", "$extensions": {"mode": {"light": "{color.gray.10}", "dark": "{color.gray.90}"}}},
+        "95": {"$value": "{color.gray.10}", "$extensions": {"mode": {"light": "{color.gray.10}", "dark": "{color.gray.95}"}}},
+        "100": {"$value": "{color.gray.0}", "$extensions": {"mode": {"light": "{color.gray.0}", "dark": "{color.gray.100}"}}}
+      },
+      "action": {
+        "10": {"$value": "{color.blue.10}"},
+        "15": {"$value": "{color.blue.15}"},
+        "20": {"$value": "{color.blue.20}"},
+        "25": {"$value": "{color.blue.25}"},
+        "30": {"$value": "{color.blue.30}"},
+        "40": {"$value": "{color.blue.40}"},
+        "50": {"$value": "{color.blue.50}"},
+        "60": {"$value": "{color.blue.60}"},
+        "70": {"$value": "{color.blue.70}"},
+        "80": {"$value": "{color.blue.80}"},
+        "85": {"$value": "{color.blue.85}"},
+        "90": {"$value": "{color.blue.90}"},
+        "95": {"$value": "{color.blue.95}"}
+      }
+    }
+  }
+}

--- a/packages/cli/test/fixtures/bundle-default/tokens.config.js
+++ b/packages/cli/test/fixtures/bundle-default/tokens.config.js
@@ -1,0 +1,6 @@
+import pluginJs from '../../../../plugin-js/dist/index.js';
+
+export default {
+  tokens: ['base.json', 'semantic.json', 'typography.json'],
+  plugins: [pluginJs()],
+};

--- a/packages/cli/test/fixtures/bundle-default/typography.json
+++ b/packages/cli/test/fixtures/bundle-default/typography.json
@@ -1,0 +1,29 @@
+{
+  "color": {
+    "$type": "color",
+    "black": {
+      "$value": "#081f2f"
+    }
+  },
+  "typography": {
+    "$type": "typography",
+    "family": {
+      "base": {"$type": "fontName", "$value": ["system-ui", "sans-serif"]},
+      "mono": {"$type": "fontName", "$value": ["ui-monospace", "monospace"]}
+    },
+    "base": {
+      "$value": {
+        "fontFamily": "{typography.family.base}",
+        "fontSize": "0.875rem",
+        "lineHeight": "1.2"
+      }
+    },
+    "code": {
+      "$value": {
+        "fontFamily": "{typography.family.mono}",
+        "fontSize": "0.875rem",
+        "lineHeight": "1.5"
+      }
+    }
+  }
+}

--- a/packages/cli/test/fixtures/bundle-default/want/bundled.json
+++ b/packages/cli/test/fixtures/bundle-default/want/bundled.json
@@ -1,0 +1,324 @@
+{
+  "color": {
+    "$type": "color",
+    "black": {
+      "$value": "#081f2f"
+    },
+    "blue": {
+      "10": {
+        "$value": "oklch(10% 0.069574 264)"
+      },
+      "15": {
+        "$value": "oklch(15% 0.102086 265)"
+      },
+      "20": {
+        "$value": "oklch(20% 0.000304 265)"
+      },
+      "25": {
+        "$value": "oklch(25% 0.172216 265)"
+      },
+      "30": {
+        "$value": "oklch(30% 0.203543 266)"
+      },
+      "40": {
+        "$value": "oklch(40% 0.216254 267)"
+      },
+      "50": {
+        "$value": "oklch(50% 0.216583 268)"
+      },
+      "60": {
+        "$value": "oklch(60% 0.216564 269)"
+      },
+      "70": {
+        "$value": "oklch(70% 0.156718 268)"
+      },
+      "80": {
+        "$value": "oklch(80% 0.10054 267)"
+      },
+      "85": {
+        "$value": "oklch(85% 0.073053 266)"
+      },
+      "90": {
+        "$value": "oklch(90% 0.048514 265)"
+      },
+      "95": {
+        "$value": "oklch(95% 0.023788 264)"
+      }
+    },
+    "gray": {
+      "0": {
+        "$value": "{color.black}"
+      },
+      "10": {
+        "$value": "#00040d"
+      },
+      "15": {
+        "$value": "#040d18"
+      },
+      "20": {
+        "$value": "#0e1823"
+      },
+      "25": {
+        "$value": "#1a232f"
+      },
+      "30": {
+        "$value": "#262f3c"
+      },
+      "40": {
+        "$value": "#414956"
+      },
+      "50": {
+        "$value": "#5d6471"
+      },
+      "60": {
+        "$value": "#7a808d"
+      },
+      "70": {
+        "$value": "#999eaa"
+      },
+      "80": {
+        "$value": "#b9bec8"
+      },
+      "85": {
+        "$value": "#c9ced8"
+      },
+      "90": {
+        "$value": "#dadee7"
+      },
+      "95": {
+        "$value": "#ebeef7"
+      },
+      "100": {
+        "$value": "{color.white}"
+      }
+    },
+    "darkGray": {
+      "$value": "#282a37"
+    },
+    "green": {
+      "$value": "#77cd8f"
+    },
+    "purple": {
+      "$value": "#6a35d9"
+    },
+    "red": {
+      "$value": "#f6566a"
+    },
+    "white": {
+      "$value": "#ffffff"
+    },
+    "ui": {
+      "contrast": {
+        "0": {
+          "$value": "{color.gray.100}",
+          "$extensions": {
+            "mode": {
+              "light": "{color.gray.100}",
+              "dark": "{color.gray.0}"
+            }
+          }
+        },
+        "10": {
+          "$value": "{color.gray.90}",
+          "$extensions": {
+            "mode": {
+              "light": "{color.gray.90}",
+              "dark": "{color.gray.10}"
+            }
+          }
+        },
+        "15": {
+          "$value": "{color.gray.85}",
+          "$extensions": {
+            "mode": {
+              "light": "{color.gray.85}",
+              "dark": "{color.gray.15}"
+            }
+          }
+        },
+        "20": {
+          "$value": "{color.gray.80}",
+          "$extensions": {
+            "mode": {
+              "light": "{color.gray.80}",
+              "dark": "{color.gray.20}"
+            }
+          }
+        },
+        "30": {
+          "$value": "{color.gray.70}",
+          "$extensions": {
+            "mode": {
+              "light": "{color.gray.70}",
+              "dark": "{color.gray.30}"
+            }
+          }
+        },
+        "40": {
+          "$value": "{color.gray.60}",
+          "$extensions": {
+            "mode": {
+              "light": "{color.gray.60}",
+              "dark": "{color.gray.40}"
+            }
+          }
+        },
+        "50": {
+          "$value": "{color.gray.50}",
+          "$extensions": {
+            "mode": {
+              "light": "{color.gray.50}",
+              "dark": "{color.gray.50}"
+            }
+          }
+        },
+        "60": {
+          "$value": "{color.gray.40}",
+          "$extensions": {
+            "mode": {
+              "light": "{color.gray.40}",
+              "dark": "{color.gray.60}"
+            }
+          }
+        },
+        "70": {
+          "$value": "{color.gray.30}",
+          "$extensions": {
+            "mode": {
+              "light": "{color.gray.30}",
+              "dark": "{color.gray.70}"
+            }
+          }
+        },
+        "80": {
+          "$value": "{color.gray.20}",
+          "$extensions": {
+            "mode": {
+              "light": "{color.gray.20}",
+              "dark": "{color.gray.80}"
+            }
+          }
+        },
+        "85": {
+          "$value": "{color.gray.15}",
+          "$extensions": {
+            "mode": {
+              "light": "{color.gray.15}",
+              "dark": "{color.gray.85}"
+            }
+          }
+        },
+        "90": {
+          "$value": "{color.gray.10}",
+          "$extensions": {
+            "mode": {
+              "light": "{color.gray.10}",
+              "dark": "{color.gray.90}"
+            }
+          }
+        },
+        "95": {
+          "$value": "{color.gray.10}",
+          "$extensions": {
+            "mode": {
+              "light": "{color.gray.10}",
+              "dark": "{color.gray.95}"
+            }
+          }
+        },
+        "100": {
+          "$value": "{color.gray.0}",
+          "$extensions": {
+            "mode": {
+              "light": "{color.gray.0}",
+              "dark": "{color.gray.100}"
+            }
+          }
+        },
+        "05": {
+          "$value": "{color.gray.95}",
+          "$extensions": {
+            "mode": {
+              "light": "{color.gray.95}",
+              "dark": "{color.gray.10}"
+            }
+          }
+        }
+      },
+      "action": {
+        "10": {
+          "$value": "{color.blue.10}"
+        },
+        "15": {
+          "$value": "{color.blue.15}"
+        },
+        "20": {
+          "$value": "{color.blue.20}"
+        },
+        "25": {
+          "$value": "{color.blue.25}"
+        },
+        "30": {
+          "$value": "{color.blue.30}"
+        },
+        "40": {
+          "$value": "{color.blue.40}"
+        },
+        "50": {
+          "$value": "{color.blue.50}"
+        },
+        "60": {
+          "$value": "{color.blue.60}"
+        },
+        "70": {
+          "$value": "{color.blue.70}"
+        },
+        "80": {
+          "$value": "{color.blue.80}"
+        },
+        "85": {
+          "$value": "{color.blue.85}"
+        },
+        "90": {
+          "$value": "{color.blue.90}"
+        },
+        "95": {
+          "$value": "{color.blue.95}"
+        }
+      }
+    }
+  },
+  "typography": {
+    "$type": "typography",
+    "family": {
+      "base": {
+        "$type": "fontName",
+        "$value": [
+          "system-ui",
+          "sans-serif"
+        ]
+      },
+      "mono": {
+        "$type": "fontName",
+        "$value": [
+          "ui-monospace",
+          "monospace"
+        ]
+      }
+    },
+    "base": {
+      "$value": {
+        "fontFamily": "{typography.family.base}",
+        "fontSize": "0.875rem",
+        "lineHeight": "1.2"
+      }
+    },
+    "code": {
+      "$value": {
+        "fontFamily": "{typography.family.mono}",
+        "fontSize": "0.875rem",
+        "lineHeight": "1.5"
+      }
+    }
+  }
+}

--- a/packages/cli/test/fixtures/bundle-default/want/bundled.yaml
+++ b/packages/cli/test/fixtures/bundle-default/want/bundled.yaml
@@ -1,0 +1,214 @@
+color:
+  $type: color
+  black:
+    $value: '#081f2f'
+  blue:
+    '10':
+      $value: oklch(10% 0.069574 264)
+    '15':
+      $value: oklch(15% 0.102086 265)
+    '20':
+      $value: oklch(20% 0.000304 265)
+    '25':
+      $value: oklch(25% 0.172216 265)
+    '30':
+      $value: oklch(30% 0.203543 266)
+    '40':
+      $value: oklch(40% 0.216254 267)
+    '50':
+      $value: oklch(50% 0.216583 268)
+    '60':
+      $value: oklch(60% 0.216564 269)
+    '70':
+      $value: oklch(70% 0.156718 268)
+    '80':
+      $value: oklch(80% 0.10054 267)
+    '85':
+      $value: oklch(85% 0.073053 266)
+    '90':
+      $value: oklch(90% 0.048514 265)
+    '95':
+      $value: oklch(95% 0.023788 264)
+  gray:
+    '0':
+      $value: '{color.black}'
+    '10':
+      $value: '#00040d'
+    '15':
+      $value: '#040d18'
+    '20':
+      $value: '#0e1823'
+    '25':
+      $value: '#1a232f'
+    '30':
+      $value: '#262f3c'
+    '40':
+      $value: '#414956'
+    '50':
+      $value: '#5d6471'
+    '60':
+      $value: '#7a808d'
+    '70':
+      $value: '#999eaa'
+    '80':
+      $value: '#b9bec8'
+    '85':
+      $value: '#c9ced8'
+    '90':
+      $value: '#dadee7'
+    '95':
+      $value: '#ebeef7'
+    '100':
+      $value: '{color.white}'
+  darkGray:
+    $value: '#282a37'
+  green:
+    $value: '#77cd8f'
+  purple:
+    $value: '#6a35d9'
+  red:
+    $value: '#f6566a'
+  white:
+    $value: '#ffffff'
+  ui:
+    contrast:
+      '0':
+        $value: '{color.gray.100}'
+        $extensions:
+          mode:
+            light: '{color.gray.100}'
+            dark: '{color.gray.0}'
+      '10':
+        $value: '{color.gray.90}'
+        $extensions:
+          mode:
+            light: '{color.gray.90}'
+            dark: '{color.gray.10}'
+      '15':
+        $value: '{color.gray.85}'
+        $extensions:
+          mode:
+            light: '{color.gray.85}'
+            dark: '{color.gray.15}'
+      '20':
+        $value: '{color.gray.80}'
+        $extensions:
+          mode:
+            light: '{color.gray.80}'
+            dark: '{color.gray.20}'
+      '30':
+        $value: '{color.gray.70}'
+        $extensions:
+          mode:
+            light: '{color.gray.70}'
+            dark: '{color.gray.30}'
+      '40':
+        $value: '{color.gray.60}'
+        $extensions:
+          mode:
+            light: '{color.gray.60}'
+            dark: '{color.gray.40}'
+      '50':
+        $value: '{color.gray.50}'
+        $extensions:
+          mode:
+            light: '{color.gray.50}'
+            dark: '{color.gray.50}'
+      '60':
+        $value: '{color.gray.40}'
+        $extensions:
+          mode:
+            light: '{color.gray.40}'
+            dark: '{color.gray.60}'
+      '70':
+        $value: '{color.gray.30}'
+        $extensions:
+          mode:
+            light: '{color.gray.30}'
+            dark: '{color.gray.70}'
+      '80':
+        $value: '{color.gray.20}'
+        $extensions:
+          mode:
+            light: '{color.gray.20}'
+            dark: '{color.gray.80}'
+      '85':
+        $value: '{color.gray.15}'
+        $extensions:
+          mode:
+            light: '{color.gray.15}'
+            dark: '{color.gray.85}'
+      '90':
+        $value: '{color.gray.10}'
+        $extensions:
+          mode:
+            light: '{color.gray.10}'
+            dark: '{color.gray.90}'
+      '95':
+        $value: '{color.gray.10}'
+        $extensions:
+          mode:
+            light: '{color.gray.10}'
+            dark: '{color.gray.95}'
+      '100':
+        $value: '{color.gray.0}'
+        $extensions:
+          mode:
+            light: '{color.gray.0}'
+            dark: '{color.gray.100}'
+      '05':
+        $value: '{color.gray.95}'
+        $extensions:
+          mode:
+            light: '{color.gray.95}'
+            dark: '{color.gray.10}'
+    action:
+      '10':
+        $value: '{color.blue.10}'
+      '15':
+        $value: '{color.blue.15}'
+      '20':
+        $value: '{color.blue.20}'
+      '25':
+        $value: '{color.blue.25}'
+      '30':
+        $value: '{color.blue.30}'
+      '40':
+        $value: '{color.blue.40}'
+      '50':
+        $value: '{color.blue.50}'
+      '60':
+        $value: '{color.blue.60}'
+      '70':
+        $value: '{color.blue.70}'
+      '80':
+        $value: '{color.blue.80}'
+      '85':
+        $value: '{color.blue.85}'
+      '90':
+        $value: '{color.blue.90}'
+      '95':
+        $value: '{color.blue.95}'
+typography:
+  $type: typography
+  family:
+    base:
+      $type: fontName
+      $value:
+        - system-ui
+        - sans-serif
+    mono:
+      $type: fontName
+      $value:
+        - ui-monospace
+        - monospace
+  base:
+    $value:
+      fontFamily: '{typography.family.base}'
+      fontSize: 0.875rem
+      lineHeight: '1.2'
+  code:
+    $value:
+      fontFamily: '{typography.family.mono}'
+      fontSize: 0.875rem
+      lineHeight: '1.5'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,11 +27,11 @@ importers:
         specifier: ^8.45.0
         version: 8.45.0
       eslint-config-prettier:
-        specifier: ^8.8.0
-        version: 8.8.0(eslint@8.45.0)
+        specifier: ^8.9.0
+        version: 8.9.0(eslint@8.45.0)
       eslint-plugin-prettier:
         specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.45.0)(prettier@2.8.8)
+        version: 4.2.1(eslint-config-prettier@8.9.0)(eslint@8.45.0)(prettier@2.8.8)
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -793,7 +793,7 @@ packages:
       '@types/semver': 7.5.0
       ansi-colors: 4.1.3
       chalk: 2.4.2
-      enquirer: 2.3.6
+      enquirer: 2.4.0
       external-editor: 3.1.0
       fs-extra: 7.0.1
       human-id: 1.0.2
@@ -2720,11 +2720,12 @@ packages:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: true
 
-  /enquirer@2.3.6:
-    resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
+  /enquirer@2.4.0:
+    resolution: {integrity: sha512-ehu97t6FTYK2I3ZYtnp0BZ9vt0mvEL/cnHBds7Ct6jo9VX1VIkiFhOvVRWh6eblQqd7KOoICIQV+syZ3neXO/Q==}
     engines: {node: '>=8.6'}
     dependencies:
       ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
     dev: true
 
   /entities@4.5.0:
@@ -2891,8 +2892,8 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /eslint-config-prettier@8.8.0(eslint@8.45.0):
-    resolution: {integrity: sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==}
+  /eslint-config-prettier@8.9.0(eslint@8.45.0):
+    resolution: {integrity: sha512-+sbni7NfVXnOpnRadUA8S28AUlsZt9GjgFvABIRL9Hkn8KqNzOp+7Lw4QWtrwn20KzU3wqu1QoOj2m+7rKRqkA==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
@@ -2900,7 +2901,7 @@ packages:
       eslint: 8.45.0
     dev: true
 
-  /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0)(eslint@8.45.0)(prettier@2.8.8):
+  /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.9.0)(eslint@8.45.0)(prettier@2.8.8):
     resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -2912,7 +2913,7 @@ packages:
         optional: true
     dependencies:
       eslint: 8.45.0
-      eslint-config-prettier: 8.8.0(eslint@8.45.0)
+      eslint-config-prettier: 8.9.0(eslint@8.45.0)
       prettier: 2.8.8
       prettier-linter-helpers: 1.0.0
     dev: true


### PR DESCRIPTION
Adds `co bundle` command for combining multiple schemas into one.

Run independently of `co build`, which by default **will not output a bundled tokens file**