### PR TITLE
chore: update font weight token code snippet

### DIFF
--- a/docs/src/pages/docs/tokens/index.astro
+++ b/docs/src/pages/docs/tokens/index.astro
@@ -131,7 +131,7 @@ const tokenDef = {
     <tbody>
       <tr>
         <td><code>$type</code></td>
-        <td><code>number</code> or <code>string</code></td>
+        <td><code>string</code></td>
         <td><b>fontWeight</b></td>
       </tr>
       <tr>
@@ -144,15 +144,16 @@ const tokenDef = {
 
   <JSONYaml
     code={`{
-  "no-fallbacks": {
-    "$type": "fontFamily",
-    "$value": "Graphik Regular"
+  "font-weight-default": {
+    "$value": 350,
+    "$type": "fontWeight"
   },
-  "with-fallbacks": {
-    "$type": "fontFamily",
-    "$value": ["Graphik Regular", "-system-ui", "Helvetica", "sans-serif"]
+  "font-weight-thick": {
+    "$value": "extra-bold",
+    "$type": "fontWeight"
   }
 }`}
+
   />
 
   <h2 id="dimension">


### PR DESCRIPTION
## Changes
I noticed the font weight section of the docs repeated the font family code snippet. I updated it, borrowing the code snippet shown in the Design Tokens spec: https://design-tokens.github.io/community-group/format/#font-weight

As well as this I updated the type  to be string. I assumed that 'number' is not a valid value for the $type

## How to Review

Check to see if the docs update I made looks good and on-par with the Design token spec. 


Here is a screenshot of the updated docs, from running locally
<img width="1076" alt="Screenshot 2023-08-15 at 18 42 29" src="https://github.com/drwpow/cobalt-ui/assets/1307818/94a80f86-8389-4b5d-98bf-69a692305f6b">



