### PR TITLE
Fix trailing slash being necessary in outDir

### DIFF
--- a/.changeset/orange-adults-fetch.md
+++ b/.changeset/orange-adults-fetch.md
@@ -1,0 +1,5 @@
+---
+'@cobalt-ui/cli': patch
+---
+
+Fix trailing slash being necessary in config.outDir

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -4,6 +4,7 @@ import mod from 'node:module';
 import {fileURLToPath, URL} from 'node:url';
 
 const require = mod.createRequire(`file://${process.cwd()}`);
+const TRAILING_SLASH_RE = /\/*$/;
 
 export async function init(userConfig: Config, cwd: URL): Promise<ResolvedConfig> {
   let config = {...(userConfig as any)} as ResolvedConfig;
@@ -61,7 +62,8 @@ export async function init(userConfig: Config, cwd: URL): Promise<ResolvedConfig
   }
   // normalize
   else {
-    config.outDir = new URL(userConfig.outDir, cwd);
+    // note: always add trailing slash so URL treats it as a directory
+    config.outDir = new URL(userConfig.outDir.replace(TRAILING_SLASH_RE, '/'), cwd);
   }
 
   // config.plugins

--- a/packages/cli/test/build.test.js
+++ b/packages/cli/test/build.test.js
@@ -38,4 +38,16 @@ describe('co build', () => {
       $value: '#081f2f',
     });
   });
+
+  describe('config', () => {
+    it('outDir', async () => {
+      const cwd = new URL('./fixtures/build-custom-dir/', import.meta.url);
+      await execa('node', [cmd, 'build'], {cwd});
+
+      const builtTokens = await import('./fixtures/build-custom-dir/src/tokens/index.js');
+
+      // rough token count
+      expect(Object.keys(builtTokens.meta).length).toBe(34);
+    });
+  });
 });

--- a/packages/cli/test/fixtures/build-custom-dir/tokens.config.js
+++ b/packages/cli/test/fixtures/build-custom-dir/tokens.config.js
@@ -1,0 +1,6 @@
+import pluginJs from '../../../../plugin-js/dist/index.js';
+
+export default {
+  outDir: 'src/tokens',
+  plugins: [pluginJs()],
+};

--- a/packages/cli/test/fixtures/build-custom-dir/tokens.json
+++ b/packages/cli/test/fixtures/build-custom-dir/tokens.json
@@ -1,0 +1,47 @@
+{
+  "color": {
+    "$type": "color",
+    "black": {
+      "$type": "color",
+      "$description": "This will get overridden in typography.json (on purpose)",
+      "$value": "#00193f"
+    },
+    "blue": {
+      "10": {"$value": "oklch(10% 0.069574 264)"},
+      "15": {"$value": "oklch(15% 0.102086 265)"},
+      "20": {"$value": "oklch(20% 0.000304 265)"},
+      "25": {"$value": "oklch(25% 0.172216 265)"},
+      "30": {"$value": "oklch(30% 0.203543 266)"},
+      "40": {"$value": "oklch(40% 0.216254 267)"},
+      "50": {"$value": "oklch(50% 0.216583 268)"},
+      "60": {"$value": "oklch(60% 0.216564 269)"},
+      "70": {"$value": "oklch(70% 0.156718 268)"},
+      "80": {"$value": "oklch(80% 0.10054 267)"},
+      "85": {"$value": "oklch(85% 0.073053 266)"},
+      "90": {"$value": "oklch(90% 0.048514 265)"},
+      "95": {"$value": "oklch(95% 0.023788 264)"}
+    },
+    "gray": {
+      "0": {"$value": "{color.black}"},
+      "10": {"$value": "#00040d"},
+      "15": {"$value": "#040d18"},
+      "20": {"$value": "#0e1823"},
+      "25": {"$value": "#1a232f"},
+      "30": {"$value": "#262f3c"},
+      "40": {"$value": "#414956"},
+      "50": {"$value": "#5d6471"},
+      "60": {"$value": "#7a808d"},
+      "70": {"$value": "#999eaa"},
+      "80": {"$value": "#b9bec8"},
+      "85": {"$value": "#c9ced8"},
+      "90": {"$value": "#dadee7"},
+      "95": {"$value": "#ebeef7"},
+      "100": {"$value": "{color.white}"}
+    },
+    "darkGray": {"$value": "#282a37"},
+    "green": {"$value": "#77cd8f"},
+    "purple": {"$value": "#6a35d9"},
+    "red": {"$value": "#f6566a"},
+    "white": {"$value": "#ffffff"}
+  }
+}


### PR DESCRIPTION
## Changes

If you specified `outDir: 'src/tokens'`, it would output to `src/` rather than `src/tokens/`.

## How to Review

- Tests should pass
