### PR TITLE
plugin-css: Fix fontFamily alias bug

### DIFF
--- a/.changeset/shaggy-pens-refuse.md
+++ b/.changeset/shaggy-pens-refuse.md
@@ -1,0 +1,5 @@
+---
+'@cobalt-ui/plugin-css': patch
+---
+
+Fix fontFamily alias bug

--- a/packages/core/test/w3c.test.ts
+++ b/packages/core/test/w3c.test.ts
@@ -192,9 +192,22 @@ describe('8. Type', () => {
     });
 
     test('array', () => {
-      const json = {typography: {body: {$type: 'fontFamily', $value: ['-system-ui', 'Helvetica']}}};
+      const json = {typography: {body: {$type: 'fontFamily', $value: ['system-ui', 'Helvetica']}}};
       const tokens = getTokens(json);
       expect(tokens.find((t) => t.id === 'typography.body')?.$value).toEqual(json.typography.body.$value);
+    });
+
+    test('alias', () => {
+      const json = {
+        typography: {
+          family: {
+            base: {$type: 'fontFamily', $value: ['Helvetica', 'system-ui']},
+            heading: {$type: 'fontFamily', $value: '{typography.family.base}'},
+          },
+        },
+      };
+      const tokens = getTokens(json);
+      expect(tokens.find((t) => t.id === 'typography.family.heading')?.$value).toEqual(json.typography.family.base.$value);
     });
   });
 
@@ -441,7 +454,7 @@ describe('9. Composite Type', () => {
         typography: {
           pageTitle: {
             $type: 'typography',
-            $value: {fontFamily: ['Helvetica', '-system-ui'], fontSize: '64px', letterSpacing: '-0.01em', lineHeight: 1.25},
+            $value: {fontFamily: ['Helvetica', 'system-ui'], fontSize: '64px', letterSpacing: '-0.01em', lineHeight: 1.25},
           },
         },
       };
@@ -470,7 +483,7 @@ describe('9. Composite Type', () => {
     test('alias: property', () => {
       const json = {
         typography: {
-          family: {heading: {$type: 'fontFamily', $value: ['Helvetica', '-system-ui']}},
+          family: {heading: {$type: 'fontFamily', $value: ['Helvetica', 'system-ui']}},
           pageTitle: {
             $type: 'typography',
             $value: {

--- a/packages/plugin-css/src/index.ts
+++ b/packages/plugin-css/src/index.ts
@@ -23,6 +23,7 @@ import {converter, formatCss} from 'culori';
 import {indent, isAlias, kebabinate, FG_YELLOW, RESET} from '@cobalt-ui/utils';
 import {encode, formatFontNames} from './util.js';
 
+const CSS_VAR_RE = /^var\(--[^)]+\)$/;
 const DASH_PREFIX_RE = /^-+/;
 const DASH_SUFFIX_RE = /-+$/;
 const DOT_UNDER_GLOB_RE = /[._]/g;
@@ -288,6 +289,11 @@ export function defaultTransformer(token: ParsedToken, options?: {mode?: string;
       resolvedVal[k] = isAlias(v) ? varRef(v, refOptions) : (value as any)[k];
     }
     value = resolvedVal;
+  }
+
+  // if this is a flat CSS var, no need to transform
+  if (typeof value === 'string' && CSS_VAR_RE.test(value)) {
+    return value;
   }
 
   switch (token.$type) {

--- a/packages/plugin-css/test/typography/tokens.json
+++ b/packages/plugin-css/test/typography/tokens.json
@@ -2,6 +2,7 @@
   "typography": {
     "family": {
       "body": {"$type": "fontFamily", "$value": ["IBM Plex Sans", "-system-ui", "sans-serif"]},
+      "footnote": {"$type": "fontFamily", "$value": "{typography.family.body}"},
       "heading": {"$type": "fontFamily", "$value": "Helvetica"}
     },
     "page-title": {

--- a/packages/plugin-css/test/typography/want.css
+++ b/packages/plugin-css/test/typography/want.css
@@ -6,6 +6,7 @@
 
 :root {
   --ds-typography-family-body: "IBM Plex Sans", -system-ui, sans-serif;
+  --ds-typography-family-footnote: var(--ds-typography-family-body);
   --ds-typography-family-heading: Helvetica;
   --ds-typography-page-title-font-family: var(--ds-typography-family-heading);
   --ds-typography-page-title-font-size: 48px;


### PR DESCRIPTION
## Changes

In `@cobalt-ui/plugin-css`, when you aliased a `fontFamily` token it would break. It was expecting an array of font names but in the previous step it may have been transformed to a CSS var.

## How to Review

- Tests added
