### PR TITLE
Allow modeSelectors globs, improve modeSelectors API

### DIFF
--- a/.changeset/dry-days-drum.md
+++ b/.changeset/dry-days-drum.md
@@ -1,0 +1,5 @@
+---
+'@cobalt-ui/plugin-css': minor
+---
+
+Improve modeSelectors API

--- a/.changeset/tidy-trains-occur.md
+++ b/.changeset/tidy-trains-occur.md
@@ -1,0 +1,5 @@
+---
+'@cobalt-ui/plugin-css': minor
+---
+
+Add glob support for modeSelectors token matching

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,10 +22,10 @@
     "@cobalt-ui/core": "workspace:*",
     "@cobalt-ui/plugin-css": "workspace:*",
     "@cobalt-ui/plugin-sass": "workspace:*",
-    "astro": "^2.10.14",
+    "astro": "^2.10.15",
     "npm-run-all": "^4.1.5",
     "sass": "^1.66.1",
-    "shiki": "^0.14.3",
+    "shiki": "^0.14.4",
     "vite": "^4.4.9"
   }
 }

--- a/docs/src/pages/docs/guides/modes.astro
+++ b/docs/src/pages/docs/guides/modes.astro
@@ -111,14 +111,14 @@ export default {
   outDir: './tokens/',
   plugins: [
     pluginCSS({
-      modeSelectors: {
-        '#light': ['@media (prefers-color-scheme: light)', 'body[data-color-mode="light"]'],
-        '#lightHighContrast': ['@media (prefers-color-scheme: light) and (prefers-contrast: more)', 'body[data-color-mode="lightHighContrast"]'],
-        '#lightColorblind': ['body[data-color-mode="lightColorblind"]'],
-        '#dark': ['@media (prefers-color-scheme: dark)', 'body[data-color-mode="dark"]'],
-        '#darkHighContrast': ['@media (prefers-color-scheme: dark) and (prefers-contrast: more)', 'body[data-color-mode="darkHighContrast"]'],
-        '#darkColorblind': ['body[data-color-mode="darkColorblind"]'],
-      },
+      modeSelectors: [
+        {mode: 'light',             selectors: ['@media (prefers-color-scheme: light)', 'body[data-color-mode="light"]']},
+        {mode: 'lightHighContrast', selectors: ['@media (prefers-color-scheme: light) and (prefers-contrast: more)', 'body[data-color-mode="lightHighContrast"]']},
+        {mode: 'lightColorblind',   selectors: ['body[data-color-mode="lightColorblind"]']},
+        {mode: 'dark',              selectors: ['@media (prefers-color-scheme: dark)', 'body[data-color-mode="dark"]']},
+        {mode: 'darkHighContrast',  selectors: ['@media (prefers-color-scheme: dark) and (prefers-contrast: more)', 'body[data-color-mode="darkHighContrast"]']},
+        {mode: 'darkColorblind',    selectors: ['body[data-color-mode="darkColorblind"]']},
+      ],
     }),
   ],
 };`}

--- a/docs/src/pages/docs/plugins/css.md
+++ b/docs/src/pages/docs/plugins/css.md
@@ -69,9 +69,9 @@ export default {
       /** set the filename inside outDir */
       filename: './tokens.css',
       /** create selector wrappers around modes */
-      modeSelectors: {
+      modeSelectors: [
         // …
-      },
+      ],
       /** embed file tokens? */
       embedFiles: false,
       /** (optional) transform specific token values */
@@ -132,7 +132,7 @@ In some scenarios this is preferable, but in others, this may result in too many
 
 #### Example
 
-To generate CSS for Modes, add a `modeSelectors: {}` object to your config, and specify `mode: [selector1, selector2, …]`.
+To generate CSS for Modes, add a `modeSelectors: []` array to your config, and specify `mode: [selector1, selector2, …]`.
 
 All mode names must start with the `#` character. You can also optionally filter to a token group by adding part or all of a group name before the `#`. For example, if your `color.*` tokens had `light` and `dark` mode you wanted to generate CSS for, as well as `transition.*` tokens with `reduced` modes, you could add the following selectors:
 
@@ -146,11 +146,22 @@ export default {
   outDir: './tokens/',
   plugins: [
     css({
-      modeSelectors: {
-        'color#light': ['@media (prefers-color-scheme: light)', 'body[data-color-mode="light"]'],
-        'color#dark': ['@media (prefers-color-scheme: dark)', 'body[data-color-mode="dark"]'],
-        'transition#reduced': ['@media (prefers-reduced-motion)'],
-      },
+      modeSelectors: [
+        {
+          mode: 'light', // match all tokens with $extensions.mode.light
+          selectors: ['@media (prefers-color-scheme: light)', 'body[data-color-mode="light"]'], // the following CSS selectors trigger the mode swap
+          tokens: ['color.*'], // (optional) limit to specific tokens, if desired (default: all tokens that use `mode` will be included)
+        },
+        {
+          mode: 'dark',
+          selectors: ['@media (prefers-color-scheme: dark)', 'body[data-color-mode="dark"]'],
+          tokens: 'color.*',
+        },
+        {
+          mode: 'reduced',
+          selectors: ['@media (prefers-reduced-motion)'],
+        },
+      ],
     }),
   ],
 };
@@ -205,10 +216,10 @@ export default {
   outDir: './tokens/',
   plugins: [
     css({
-      modeSelectors: {
-        'type.size#mobile': ['@media (max-width: 600px)'],
-        'type.size#desktop': ['@media (min-width: 600px)'],
-      },
+      modeSelectors: [
+        {mode: 'mobile', tokens: ['type.size.*'], selectors: ['@media (max-width: 600px)']},
+        {mode: 'desktop', tokens: ['type.size.*'], selectors: ['@media (min-width: 600px)']},
+      ],
     }),
   ],
 };

--- a/docs/src/pages/docs/plugins/sass.md
+++ b/docs/src/pages/docs/plugins/sass.md
@@ -117,10 +117,10 @@ export default {
       cssVars: true,
       pluginCSS: {
         prefix: 'ds',
-        modeSelectors: {
-          'color#light': ['[data-color-theme="light"]'],
-          'color#dark': ['[data-color-theme="dark"]'],
-        },
+        modeSelectors: [
+          {mode: 'light', tokens: ['color.*'], selectors: ['[data-color-theme="light"]']},
+          {mode: 'dark', tokens: ['color.*'], selectors: ['[data-color-theme="dark"]']},
+        ],
       },
     }),
   ],

--- a/docs/tokens.config.js
+++ b/docs/tokens.config.js
@@ -5,10 +5,10 @@ export default {
   plugins: [
     pluginSass({
       pluginCSS: {
-        modeSelectors: {
-          'ui#light': ['body[data-color-mode="light"]'],
-          'ui#dark': ['body[data-color-mode="dark"]', '@media(prefers-color-scheme:dark)'],
-        },
+        modeSelectors: [
+          {mode: 'light', tokens: ['color.ui.*'], selectors: ['body[data-color-mode="light"]']},
+          {mode: 'dark', tokens: ['color.ui.*'], selectors: ['body[data-color-mode="dark"]', '@media(prefers-color-scheme:dark)']},
+        ],
       },
     }),
   ],

--- a/docs/tokens/index.scss
+++ b/docs/tokens/index.scss
@@ -50,6 +50,30 @@ $__token-values: (
   "color.blue.95": (
     default: (var(--color-blue-95)),
   ),
+  "color.code.bg.greenShift": (
+    default: (var(--color-code-bg-greenShift)),
+  ),
+  "color.code.gold": (
+    default: (var(--color-code-gold)),
+  ),
+  "color.code.green": (
+    default: (var(--color-code-green)),
+  ),
+  "color.code.orange": (
+    default: (var(--color-code-orange)),
+  ),
+  "color.code.pink": (
+    default: (var(--color-code-pink)),
+  ),
+  "color.code.red": (
+    default: (var(--color-code-red)),
+  ),
+  "color.code.skyBlue": (
+    default: (var(--color-code-skyBlue)),
+  ),
+  "color.darkGray": (
+    default: (var(--color-darkGray)),
+  ),
   "color.gray.0": (
     default: (var(--color-gray-0)),
   ),
@@ -95,9 +119,6 @@ $__token-values: (
   "color.gray.100": (
     default: (var(--color-gray-100)),
   ),
-  "color.darkGray": (
-    default: (var(--color-darkGray)),
-  ),
   "color.green": (
     default: (var(--color-green)),
   ),
@@ -107,29 +128,10 @@ $__token-values: (
   "color.red": (
     default: (var(--color-red)),
   ),
-  "color.white": (
-    default: (var(--color-white)),
-  ),
-  "color.code.bg.greenShift": (
-    default: (var(--color-code-bg-greenShift)),
-  ),
-  "color.code.gold": (
-    default: (var(--color-code-gold)),
-  ),
-  "color.code.green": (
-    default: (var(--color-code-green)),
-  ),
-  "color.code.orange": (
-    default: (var(--color-code-orange)),
-  ),
-  "color.code.red": (
-    default: (var(--color-code-red)),
-  ),
-  "color.code.pink": (
-    default: (var(--color-code-pink)),
-  ),
-  "color.code.skyBlue": (
-    default: (var(--color-code-skyBlue)),
+  "color.ui.action": (
+    default: (var(--color-ui-action)),
+    "light": (var(--color-ui-action)),
+    "dark": (var(--color-ui-action)),
   ),
   "color.ui.contrast.0": (
     default: (var(--color-ui-contrast-0)),
@@ -206,16 +208,35 @@ $__token-values: (
     "light": (var(--color-ui-contrast-100)),
     "dark": (var(--color-ui-contrast-100)),
   ),
-  "color.ui.action": (
-    default: (var(--color-ui-action)),
-    "light": (var(--color-ui-action)),
-    "dark": (var(--color-ui-action)),
+  "color.white": (
+    default: (var(--color-white)),
   ),
-  "font.family.ppNeue": (
-    default: (var(--font-family-ppNeue)),
+  "ease.inCirc": (
+    default: (var(--ease-inCirc)),
+  ),
+  "ease.inCubic": (
+    default: (var(--ease-inCubic)),
+  ),
+  "ease.inOutCirc": (
+    default: (var(--ease-inOutCirc)),
+  ),
+  "ease.inOutCubic": (
+    default: (var(--ease-inOutCubic)),
+  ),
+  "ease.linear": (
+    default: (var(--ease-linear)),
+  ),
+  "ease.outCirc": (
+    default: (var(--ease-outCirc)),
+  ),
+  "ease.outCubic": (
+    default: (var(--ease-outCubic)),
   ),
   "font.family.mono": (
     default: (var(--font-family-mono)),
+  ),
+  "font.family.ppNeue": (
+    default: (var(--font-family-ppNeue)),
   ),
   "font.size.01": (
     default: (var(--font-size-01)),
@@ -241,77 +262,56 @@ $__token-values: (
   "font.size.08": (
     default: (var(--font-size-08)),
   ),
-  "space.4xs": (
-    default: (var(--space-4xs)),
-  ),
-  "space.3xs": (
-    default: (var(--space-3xs)),
+  "space.2xl": (
+    default: (var(--space-2xl)),
   ),
   "space.2xs": (
     default: (var(--space-2xs)),
   ),
-  "space.xs": (
-    default: (var(--space-xs)),
-  ),
-  "space.sm": (
-    default: (var(--space-sm)),
-  ),
-  "space.md": (
-    default: (var(--space-md)),
-  ),
-  "space.lg": (
-    default: (var(--space-lg)),
-  ),
-  "space.xl": (
-    default: (var(--space-xl)),
-  ),
-  "space.2xl": (
-    default: (var(--space-2xl)),
-  ),
   "space.3xl": (
     default: (var(--space-3xl)),
   ),
-  "space.layout.2xs": (
-    default: (var(--space-layout-2xs)),
+  "space.3xs": (
+    default: (var(--space-3xs)),
   ),
-  "space.layout.xs": (
-    default: (var(--space-layout-xs)),
-  ),
-  "space.layout.sm": (
-    default: (var(--space-layout-sm)),
-  ),
-  "space.layout.md": (
-    default: (var(--space-layout-md)),
-  ),
-  "space.layout.lg": (
-    default: (var(--space-layout-lg)),
-  ),
-  "space.layout.xl": (
-    default: (var(--space-layout-xl)),
+  "space.4xs": (
+    default: (var(--space-4xs)),
   ),
   "space.layout.2xl": (
     default: (var(--space-layout-2xl)),
   ),
-  "ease.linear": (
-    default: (var(--ease-linear)),
+  "space.layout.2xs": (
+    default: (var(--space-layout-2xs)),
   ),
-  "ease.inCirc": (
-    default: (var(--ease-inCirc)),
+  "space.layout.lg": (
+    default: (var(--space-layout-lg)),
   ),
-  "ease.outCirc": (
-    default: (var(--ease-outCirc)),
+  "space.layout.md": (
+    default: (var(--space-layout-md)),
   ),
-  "ease.inOutCirc": (
-    default: (var(--ease-inOutCirc)),
+  "space.layout.sm": (
+    default: (var(--space-layout-sm)),
   ),
-  "ease.outCubic": (
-    default: (var(--ease-outCubic)),
+  "space.layout.xl": (
+    default: (var(--space-layout-xl)),
   ),
-  "ease.inCubic": (
-    default: (var(--ease-inCubic)),
+  "space.layout.xs": (
+    default: (var(--space-layout-xs)),
   ),
-  "ease.inOutCubic": (
-    default: (var(--ease-inOutCubic)),
+  "space.lg": (
+    default: (var(--space-lg)),
+  ),
+  "space.md": (
+    default: (var(--space-md)),
+  ),
+  "space.sm": (
+    default: (var(--space-sm)),
+  ),
+  "space.xl": (
+    default: (var(--space-xl)),
+  ),
+  "space.xs": (
+    default: (var(--space-xs)),
   ),
 );
 

--- a/docs/tokens/tokens.css
+++ b/docs/tokens/tokens.css
@@ -19,6 +19,14 @@
   --color-blue-85: #b7cdff;
   --color-blue-90: #cedeff;
   --color-blue-95: #e6efff;
+  --color-code-bg-greenShift: #2b5eaa;
+  --color-code-gold: #ffdc2b;
+  --color-code-green: #79ff6a;
+  --color-code-orange: #ff6418;
+  --color-code-pink: #ff5ae2;
+  --color-code-red: #f56d65;
+  --color-code-skyBlue: #59c1ff;
+  --color-darkGray: #282a37;
   --color-gray-0: var(--color-black);
   --color-gray-10: #00040d;
   --color-gray-15: #040d18;
@@ -34,19 +42,12 @@
   --color-gray-90: #dadee7;
   --color-gray-95: #ebeef7;
   --color-gray-100: var(--color-white);
-  --color-darkGray: #282a37;
   --color-green: #77cd8f;
   --color-purple: #6a35d9;
   --color-red: #f6566a;
-  --color-white: #ffffff;
-  --color-code-bg-greenShift: #2b5eaa;
-  --color-code-gold: #ffdc2b;
-  --color-code-green: #79ff6a;
-  --color-code-orange: #ff6418;
-  --color-code-red: #f56d65;
-  --color-code-pink: #ff5ae2;
-  --color-code-skyBlue: #59c1ff;
+  --color-ui-action: var(--color-blue-50);
   --color-ui-contrast-0: var(--color-gray-100);
+  --color-ui-contrast-05: var(--color-gray-95);
   --color-ui-contrast-10: var(--color-gray-90);
   --color-ui-contrast-15: var(--color-gray-85);
   --color-ui-contrast-20: var(--color-gray-80);
@@ -60,10 +61,16 @@
   --color-ui-contrast-90: var(--color-gray-10);
   --color-ui-contrast-95: var(--color-gray-10);
   --color-ui-contrast-100: var(--color-gray-0);
-  --color-ui-contrast-05: var(--color-gray-95);
-  --color-ui-action: var(--color-blue-50);
-  --font-family-ppNeue: "PP Neue Montreal", system-ui, ui-sans-serif, -apple-system, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --color-white: #ffffff;
+  --ease-inCirc: cubic-bezier(0.55, 0, 1, 0.45);
+  --ease-inCubic: cubic-bezier(0.32, 0, 0.67, 1);
+  --ease-inOutCirc: cubic-bezier(0.85, 0, 0.15, 1);
+  --ease-inOutCubic: cubic-bezier(0.65, 0, 0.35, 1);
+  --ease-linear: cubic-bezier(0, 0, 1, 1);
+  --ease-outCirc: cubic-bezier(0, 0.55, 0.45, 1);
+  --ease-outCubic: cubic-bezier(0.33, 1, 0.68, 1);
   --font-family-mono: "Red Hat Mono", ui-monospace, "SF Mono", Monaco, "Cascadia Mono", "Cascadia Code", Consolas, monospace;
+  --font-family-ppNeue: "PP Neue Montreal", system-ui, ui-sans-serif, -apple-system, "Helvetica Neue", Helvetica, Arial, sans-serif;
   --font-size-01: 8px;
   --font-size-02: 9px;
   --font-size-03: 12px;
@@ -72,30 +79,82 @@
   --font-size-06: 22px;
   --font-size-07: 28px;
   --font-size-08: 32px;
-  --space-4xs: 1px;
-  --space-3xs: 0.125rem;
-  --space-2xs: 0.25rem;
-  --space-xs: 0.5rem;
-  --space-sm: 0.75rem;
-  --space-md: 1rem;
-  --space-lg: 1.5rem;
-  --space-xl: 2rem;
   --space-2xl: 2.5rem;
+  --space-2xs: 0.25rem;
   --space-3xl: 3rem;
-  --space-layout-2xs: 1rem;
-  --space-layout-xs: 1.5rem;
-  --space-layout-sm: 2rem;
-  --space-layout-md: 3rem;
-  --space-layout-lg: 4rem;
-  --space-layout-xl: 6rem;
+  --space-3xs: 0.125rem;
+  --space-4xs: 1px;
   --space-layout-2xl: 10rem;
-  --ease-linear: cubic-bezier(0, 0, 1, 1);
-  --ease-inCirc: cubic-bezier(0.55, 0, 1, 0.45);
-  --ease-outCirc: cubic-bezier(0, 0.55, 0.45, 1);
-  --ease-inOutCirc: cubic-bezier(0.85, 0, 0.15, 1);
-  --ease-outCubic: cubic-bezier(0.33, 1, 0.68, 1);
-  --ease-inCubic: cubic-bezier(0.32, 0, 0.67, 1);
-  --ease-inOutCubic: cubic-bezier(0.65, 0, 0.35, 1);
+  --space-layout-2xs: 1rem;
+  --space-layout-lg: 4rem;
+  --space-layout-md: 3rem;
+  --space-layout-sm: 2rem;
+  --space-layout-xl: 6rem;
+  --space-layout-xs: 1.5rem;
+  --space-lg: 1.5rem;
+  --space-md: 1rem;
+  --space-sm: 0.75rem;
+  --space-xl: 2rem;
+  --space-xs: 0.5rem;
+}
+
+body[data-color-mode="light"] {
+  --color-ui-action: var(--color-blue-50);
+  --color-ui-contrast-0: var(--color-gray-100);
+  --color-ui-contrast-05: var(--color-gray-95);
+  --color-ui-contrast-10: var(--color-gray-90);
+  --color-ui-contrast-15: var(--color-gray-85);
+  --color-ui-contrast-20: var(--color-gray-80);
+  --color-ui-contrast-30: var(--color-gray-70);
+  --color-ui-contrast-40: var(--color-gray-60);
+  --color-ui-contrast-50: var(--color-gray-50);
+  --color-ui-contrast-60: var(--color-gray-40);
+  --color-ui-contrast-70: var(--color-gray-30);
+  --color-ui-contrast-80: var(--color-gray-20);
+  --color-ui-contrast-85: var(--color-gray-15);
+  --color-ui-contrast-90: var(--color-gray-10);
+  --color-ui-contrast-95: var(--color-gray-10);
+  --color-ui-contrast-100: var(--color-gray-0);
+}
+
+body[data-color-mode="dark"] {
+  --color-ui-action: var(--color-blue-80);
+  --color-ui-contrast-0: var(--color-gray-0);
+  --color-ui-contrast-05: var(--color-gray-10);
+  --color-ui-contrast-10: var(--color-gray-10);
+  --color-ui-contrast-15: var(--color-gray-15);
+  --color-ui-contrast-20: var(--color-gray-20);
+  --color-ui-contrast-30: var(--color-gray-30);
+  --color-ui-contrast-40: var(--color-gray-40);
+  --color-ui-contrast-50: var(--color-gray-50);
+  --color-ui-contrast-60: var(--color-gray-60);
+  --color-ui-contrast-70: var(--color-gray-70);
+  --color-ui-contrast-80: var(--color-gray-80);
+  --color-ui-contrast-85: var(--color-gray-85);
+  --color-ui-contrast-90: var(--color-gray-90);
+  --color-ui-contrast-95: var(--color-gray-95);
+  --color-ui-contrast-100: var(--color-gray-100);
+}
+
+@media(prefers-color-scheme:dark) {
+  :root {
+    --color-ui-action: var(--color-blue-80);
+    --color-ui-contrast-0: var(--color-gray-0);
+    --color-ui-contrast-05: var(--color-gray-10);
+    --color-ui-contrast-10: var(--color-gray-10);
+    --color-ui-contrast-15: var(--color-gray-15);
+    --color-ui-contrast-20: var(--color-gray-20);
+    --color-ui-contrast-30: var(--color-gray-30);
+    --color-ui-contrast-40: var(--color-gray-40);
+    --color-ui-contrast-50: var(--color-gray-50);
+    --color-ui-contrast-60: var(--color-gray-60);
+    --color-ui-contrast-70: var(--color-gray-70);
+    --color-ui-contrast-80: var(--color-gray-80);
+    --color-ui-contrast-85: var(--color-gray-85);
+    --color-ui-contrast-90: var(--color-gray-90);
+    --color-ui-contrast-95: var(--color-gray-95);
+    --color-ui-contrast-100: var(--color-gray-100);
+  }
 }
 
 @supports (color: color(display-p3 1 1 1)) {
@@ -114,6 +173,14 @@
     --color-blue-85: color(display-p3 0.7176470588235294 0.803921568627451 1);
     --color-blue-90: color(display-p3 0.807843137254902 0.8705882352941177 1);
     --color-blue-95: color(display-p3 0.9019607843137255 0.9372549019607843 1);
+    --color-code-bg-greenShift: color(display-p3 0.16862745098039217 0.3686274509803922 0.6666666666666666);
+    --color-code-gold: color(display-p3 1 0.8627450980392157 0.16862745098039217);
+    --color-code-green: color(display-p3 0.4745098039215686 1 0.41568627450980394);
+    --color-code-orange: color(display-p3 1 0.39215686274509803 0.09411764705882353);
+    --color-code-pink: color(display-p3 1 0.35294117647058826 0.8862745098039215);
+    --color-code-red: color(display-p3 0.9607843137254902 0.42745098039215684 0.396078431372549);
+    --color-code-skyBlue: color(display-p3 0.34901960784313724 0.7568627450980392 1);
+    --color-darkGray: color(display-p3 0.1568627450980392 0.16470588235294117 0.21568627450980393);
     --color-gray-10: color(display-p3 0 0.01568627450980392 0.050980392156862744);
     --color-gray-15: color(display-p3 0.01568627450980392 0.050980392156862744 0.09411764705882353);
     --color-gray-20: color(display-p3 0.054901960784313725 0.09411764705882353 0.13725490196078433);
@@ -127,17 +194,9 @@
     --color-gray-85: color(display-p3 0.788235294117647 0.807843137254902 0.8470588235294118);
     --color-gray-90: color(display-p3 0.8549019607843137 0.8705882352941177 0.9058823529411765);
     --color-gray-95: color(display-p3 0.9215686274509803 0.9333333333333333 0.9686274509803922);
-    --color-darkGray: color(display-p3 0.1568627450980392 0.16470588235294117 0.21568627450980393);
     --color-green: color(display-p3 0.4666666666666667 0.803921568627451 0.5607843137254902);
     --color-purple: color(display-p3 0.41568627450980394 0.20784313725490197 0.8509803921568627);
     --color-red: color(display-p3 0.9647058823529412 0.33725490196078434 0.41568627450980394);
     --color-white: color(display-p3 1 1 1);
-    --color-code-bg-greenShift: color(display-p3 0.16862745098039217 0.3686274509803922 0.6666666666666666);
-    --color-code-gold: color(display-p3 1 0.8627450980392157 0.16862745098039217);
-    --color-code-green: color(display-p3 0.4745098039215686 1 0.41568627450980394);
-    --color-code-orange: color(display-p3 1 0.39215686274509803 0.09411764705882353);
-    --color-code-red: color(display-p3 0.9607843137254902 0.42745098039215684 0.396078431372549);
-    --color-code-pink: color(display-p3 1 0.35294117647058826 0.8862745098039215);
-    --color-code-skyBlue: color(display-p3 0.34901960784313724 0.7568627450980392 1);
   }
 }

--- a/examples/adobe/tokens.config.js
+++ b/examples/adobe/tokens.config.js
@@ -7,14 +7,14 @@ export default {
   plugins: [
     pluginCSS({
       prefix: 'spectrum',
-      modeSelectors: {
-        '#dark': ['body[data-color-mode="dark"]', '@media (prefers-color-scheme: dark)'],
-        '#darkest': ['body[data-color-mode="darkest"]'],
-        '#light': ['body[data-color-mode="light"]', '@media (prefers-color-scheme: light)'],
-        '#lightest': ['body[data-color-mode="lightest"]'],
-        '#middark': ['body[data-color-mode="middark"]'],
-        '#midlight': ['body[data-color-mode="midlight"]'],
-      },
+      modeSelectors: [
+        {mode: 'dark', selectors: ['body[data-color-mode="dark"]', '@media (prefers-color-scheme: dark)']},
+        {mode: 'darkest', selectors: ['body[data-color-mode="darkest"]']},
+        {mode: 'light', selectors: ['body[data-color-mode="light"]', '@media (prefers-color-scheme: light)']},
+        {mode: 'lightest', selectors: ['body[data-color-mode="lightest"]']},
+        {mode: 'middark', selectors: ['body[data-color-mode="middark"]']},
+        {mode: 'midlight', selectors: ['body[data-color-mode="midlight"]']},
+      ],
     }),
     pluginJS(),
     pluginSass(),

--- a/examples/github/tokens.config.js
+++ b/examples/github/tokens.config.js
@@ -6,12 +6,12 @@ import pluginJS from '@cobalt-ui/plugin-js';
 export default {
   plugins: [
     pluginCSS({
-      modeSelectors: {
-        'color#light': ['[data-color-theme="light"]'],
-        'color#light_colorblind': ['[data-color-theme="light-colorblind"]'],
-        'color#light_low_contrast': ['[data-color-theme="light-low-contrast"]'],
-        'font.size#desktop': ['@media (min-width: 600px)'],
-      },
+      modeSelectors: [
+        {mode: 'light', selectors: ['[data-color-theme="light"]']},
+        {mode: 'light_colorblind', selectors: ['[data-color-theme="light-colorblind"]']},
+        {mode: 'light_low_contrast', selectors: ['[data-color-theme="light-low-contrast"]']},
+        {mode: 'desktop', tokens: ['font.size.*'], selectors: ['@media (min-width: 600px)']},
+      ],
     }),
     pluginSass(),
     pluginJS(),

--- a/packages/plugin-css/README.md
+++ b/packages/plugin-css/README.md
@@ -64,9 +64,9 @@ export default {
       /** set the filename inside outDir */
       filename: './tokens.css',
       /** create selector wrappers around modes */
-      modeSelectors: {
+      modeSelectors: [
         // …
-      },
+      ],
       /** embed file tokens? */
       embedFiles: false,
       /** (optional) transform specific token values */
@@ -127,7 +127,7 @@ In some scenarios this is preferable, but in others, this may result in too many
 
 #### Example
 
-To generate CSS for Modes, add a `modeSelectors: {}` object to your config, and specify `mode: [selector1, selector2, …]`.
+To generate CSS for Modes, add a `modeSelectors: []` array to your config, and specify `mode: [selector1, selector2, …]`.
 
 All mode names must start with the `#` character. You can also optionally filter to a token group by adding part or all of a group name before the `#`. For example, if your `color.*` tokens had `light` and `dark` mode you wanted to generate CSS for, as well as `transition.*` tokens with `reduced` modes, you could add the following selectors:
 
@@ -141,11 +141,22 @@ export default {
   outDir: './tokens/',
   plugins: [
     css({
-      modeSelectors: {
-        'color#light': ['@media (prefers-color-scheme: light)', 'body[data-color-mode="light"]'],
-        'color#dark': ['@media (prefers-color-scheme: dark)', 'body[data-color-mode="dark"]'],
-        'transition#reduced': ['@media (prefers-reduced-motion)'],
-      },
+      modeSelectors: [
+        {
+          mode: 'light', // match all tokens with $extensions.mode.light
+          selectors: ['@media (prefers-color-scheme: light)', 'body[data-color-mode="light"]'], // the following CSS selectors trigger the mode swap
+          tokens: ['color.*'], // (optional) limit to specific tokens, if desired (default: all tokens that use `mode` will be included)
+        },
+        {
+          mode: 'dark',
+          selectors: ['@media (prefers-color-scheme: dark)', 'body[data-color-mode="dark"]'],
+          tokens: 'color.*',
+        },
+        {
+          mode: 'reduced',
+          selectors: ['@media (prefers-reduced-motion)'],
+        },
+      ],
     }),
   ],
 };
@@ -200,10 +211,10 @@ export default {
   outDir: './tokens/',
   plugins: [
     css({
-      modeSelectors: {
-        'type.size#mobile': ['@media (max-width: 600px)'],
-        'type.size#desktop': ['@media (min-width: 600px)'],
-      },
+      modeSelectors: [
+        {mode: 'mobile', tokens: ['type.size.*'], selectors: ['@media (max-width: 600px)']},
+        {mode: 'desktop', tokens: ['type.size.*'], selectors: ['@media (min-width: 600px)']},
+      ],
     }),
   ],
 };

--- a/packages/plugin-css/package.json
+++ b/packages/plugin-css/package.json
@@ -37,12 +37,14 @@
     "@types/culori": "^2.0.0",
     "@types/mime": "^3.0.1",
     "culori": "^3.2.0",
+    "micromatch": "^4.0.5",
     "mime": "^3.0.0",
     "svgo": "^3.0.2"
   },
   "devDependencies": {
     "@cobalt-ui/cli": "^1.4.2",
     "@cobalt-ui/core": "^1.4.3",
+    "@types/micromatch": "^4.0.2",
     "@types/node": "^20.5.7",
     "npm-run-all": "^4.1.5",
     "vitest": "^0.34.3"

--- a/packages/plugin-css/test/build.test.ts
+++ b/packages/plugin-css/test/build.test.ts
@@ -8,27 +8,28 @@ import pluginCSS from '../dist/index.js';
 describe('@cobalt-ui/plugin-css', () => {
   test.each(['border', 'color', 'typography', 'transition'])('%s', async (dir) => {
     const cwd = new URL(`./${dir}/`, import.meta.url);
-    const tokens = JSON.parse(fs.readFileSync(new URL('./tokens.json', cwd)));
+    const tokens = JSON.parse(fs.readFileSync(new URL('./tokens.json', cwd), 'utf8'));
     await build(tokens, {
       outDir: cwd,
       plugins: [
         pluginCSS({
           filename: 'actual.css',
           prefix: 'ds-',
-          modeSelectors: {
-            '#light': ['@media (prefers-color-scheme: light)'],
-            '#dark': ['@media (prefers-color-scheme: dark)'],
-            'color#light': ['[data-color-theme="light"]'],
-            'color#dark': ['[data-color-theme="dark"]'],
-            'color#light-colorblind': ['[data-color-theme="light-colorblind"]'],
-            'color#light-high-contrast': ['[data-color-theme="light-high-contrast"]'],
-            'color#dark-dimmed': ['[data-color-theme="dark-dimmed"]'],
-            'color#dark-high-contrast': ['[data-color-theme="high-contrast"]'],
-            'color#dark-colorblind': ['[data-color-theme="dark-colorblind"]'],
-          },
+          modeSelectors: [
+            {mode: 'light', selectors: ['@media (prefers-color-scheme: light)']},
+            {mode: 'dark', selectors: ['@media (prefers-color-scheme: dark)']},
+            {mode: 'light', tokens: ['color.*'], selectors: ['[data-color-theme="light"]']},
+            {mode: 'dark', tokens: ['color.*'], selectors: ['[data-color-theme="dark"]']},
+            {mode: 'light-colorblind', tokens: ['color.*'], selectors: ['[data-color-theme="light-colorblind"]']},
+            {mode: 'light-high-contrast', tokens: ['color.*'], selectors: ['[data-color-theme="light-high-contrast"]']},
+            {mode: 'dark-dimmed', tokens: ['color.*'], selectors: ['[data-color-theme="dark-dimmed"]']},
+            {mode: 'dark-high-contrast', tokens: ['color.*'], selectors: ['[data-color-theme="dark-high-contrast"]']},
+            {mode: 'dark-colorblind', tokens: ['color.*'], selectors: ['[data-color-theme="dark-colorblind"]']},
+          ],
         }),
       ],
       color: {},
+      tokens: [],
     });
 
     expect(fs.readFileSync(new URL('./actual.css', cwd), 'utf8')).toMatchFileSnapshot(fileURLToPath(new URL('./want.css', cwd)));
@@ -42,13 +43,14 @@ describe('@cobalt-ui/plugin-css', () => {
       plugins: [
         pluginCSS({
           filename: 'actual.css',
-          modeSelectors: {
-            'color#light': ['@media (prefers-color-scheme: light)', '[data-color-mode="light"]'],
-            'color#dark': ['@media (prefers-color-scheme: dark)', '[data-color-mode="dark"]'],
-          },
+          modeSelectors: [
+            {mode: 'light', tokens: ['color.*'], selectors: ['@media (prefers-color-scheme: light)', '[data-color-mode="light"]']},
+            {mode: 'dark', tokens: ['color.*'], selectors: ['@media (prefers-color-scheme: dark)', '[data-color-mode="dark"]']},
+          ],
         }),
       ],
       color: {},
+      tokens: [],
     });
     expect(fs.readFileSync(new URL('./actual.css', cwd), 'utf8')).toMatchFileSnapshot(fileURLToPath(new URL('./want.css', cwd)));
   });
@@ -56,7 +58,7 @@ describe('@cobalt-ui/plugin-css', () => {
   describe('options', () => {
     test('p3', async () => {
       const cwd = new URL(`./p3/`, import.meta.url);
-      const tokens = JSON.parse(fs.readFileSync(new URL('./tokens.json', cwd)));
+      const tokens = JSON.parse(fs.readFileSync(new URL('./tokens.json', cwd), 'utf8'));
       await build(tokens, {
         outDir: cwd,
         plugins: [
@@ -66,6 +68,7 @@ describe('@cobalt-ui/plugin-css', () => {
           }),
         ],
         color: {},
+        tokens: [],
       });
       expect(fs.readFileSync(new URL('./actual.css', cwd), 'utf8')).toMatchFileSnapshot(fileURLToPath(new URL('./want.css', cwd)));
     });

--- a/packages/plugin-css/test/color/want.css
+++ b/packages/plugin-css/test/color/want.css
@@ -49,7 +49,7 @@
   --ds-color-blue: #4184e4;
 }
 
-[data-color-theme="high-contrast"] {
+[data-color-theme="dark-high-contrast"] {
   --ds-color-action: var(--ds-color-blue);
   --ds-color-blue: #409eff;
 }
@@ -97,7 +97,7 @@
     --ds-color-blue: color(display-p3 0.2549019607843137 0.5176470588235295 0.8941176470588236);
   }
 
-  [data-color-theme="high-contrast"] {
+  [data-color-theme="dark-high-contrast"] {
     --ds-color-blue: color(display-p3 0.25098039215686274 0.6196078431372549 1);
   }
 

--- a/packages/plugin-sass/README.md
+++ b/packages/plugin-sass/README.md
@@ -112,10 +112,10 @@ export default {
       cssVars: true,
       pluginCSS: {
         prefix: 'ds',
-        modeSelectors: {
-          'color#light': ['[data-color-theme="light"]'],
-          'color#dark': ['[data-color-theme="dark"]'],
-        },
+        modeSelectors: [
+          {mode: 'light', tokens: ['color.*'], selectors: ['[data-color-theme="light"]']},
+          {mode: 'dark', tokens: ['color.*'], selectors: ['[data-color-theme="dark"]']},
+        ],
       },
     }),
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/plugin-sass
       astro:
-        specifier: ^2.10.14
-        version: 2.10.14(sass@1.66.1)
+        specifier: ^2.10.15
+        version: 2.10.15(sass@1.66.1)
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -76,8 +76,8 @@ importers:
         specifier: ^1.66.1
         version: 1.66.1
       shiki:
-        specifier: ^0.14.3
-        version: 0.14.3
+        specifier: ^0.14.4
+        version: 0.14.4
       vite:
         specifier: ^4.4.9
         version: 4.4.9(sass@1.66.1)
@@ -284,6 +284,9 @@ importers:
       culori:
         specifier: ^3.2.0
         version: 3.2.0
+      micromatch:
+        specifier: ^4.0.5
+        version: 4.0.5
       mime:
         specifier: ^3.0.0
         version: 3.0.0
@@ -297,6 +300,9 @@ importers:
       '@cobalt-ui/core':
         specifier: ^1.4.3
         version: link:../core
+      '@types/micromatch':
+        specifier: ^4.0.2
+        version: 4.0.2
       '@types/node':
         specifier: ^20.5.7
         version: 20.5.7
@@ -409,8 +415,8 @@ packages:
       events: 3.3.0
       prettier: 2.8.8
       prettier-plugin-astro: 0.9.1
-      vscode-css-languageservice: 6.2.6
-      vscode-html-languageservice: 5.0.6
+      vscode-css-languageservice: 6.2.7
+      vscode-html-languageservice: 5.0.7
       vscode-languageserver: 8.1.0
       vscode-languageserver-protocol: 3.17.3
       vscode-languageserver-textdocument: 1.0.8
@@ -418,13 +424,13 @@ packages:
       vscode-uri: 3.0.7
     dev: true
 
-  /@astrojs/markdown-remark@2.2.1(astro@2.10.14):
+  /@astrojs/markdown-remark@2.2.1(astro@2.10.15):
     resolution: {integrity: sha512-VF0HRv4GpC1XEMLnsKf6jth7JSmlt9qpqP0josQgA2eSpCIAC/Et+y94mgdBIZVBYH/yFnMoIxgKVe93xfO2GA==}
     peerDependencies:
       astro: ^2.5.0
     dependencies:
       '@astrojs/prism': 2.1.2
-      astro: 2.10.14(sass@1.66.1)
+      astro: 2.10.15(sass@1.66.1)
       github-slugger: 1.5.0
       import-meta-resolve: 2.2.2
       rehype-raw: 6.1.1
@@ -433,7 +439,7 @@ packages:
       remark-parse: 10.0.2
       remark-rehype: 10.1.0
       remark-smartypants: 2.0.0
-      shiki: 0.14.3
+      shiki: 0.14.4
       unified: 10.1.2
       unist-util-visit: 4.1.2
       vfile: 5.3.7
@@ -470,14 +476,6 @@ packages:
       undici: 5.23.0
     dev: true
 
-  /@babel/code-frame@7.22.10:
-    resolution: {integrity: sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/highlight': 7.22.10
-      chalk: 2.4.2
-    dev: true
-
   /@babel/code-frame@7.22.13:
     resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
     engines: {node: '>=6.9.0'}
@@ -496,12 +494,12 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.22.10
+      '@babel/code-frame': 7.22.13
       '@babel/generator': 7.22.10
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.11)
       '@babel/helpers': 7.22.11
-      '@babel/parser': 7.22.11
+      '@babel/parser': 7.22.14
       '@babel/template': 7.22.5
       '@babel/traverse': 7.22.11
       '@babel/types': 7.22.11
@@ -628,15 +626,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/highlight@7.22.10:
-    resolution: {integrity: sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.22.5
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-    dev: true
-
   /@babel/highlight@7.22.13:
     resolution: {integrity: sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==}
     engines: {node: '>=6.9.0'}
@@ -646,8 +635,8 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /@babel/parser@7.22.11:
-    resolution: {integrity: sha512-R5zb8eJIBPJriQtbH/htEQy4k7E2dHWlD2Y2VT07JCzwYZHBxV5ZYtM0UhXSNMT74LyxuM+b1jdL7pSesXbC/g==}
+  /@babel/parser@7.22.14:
+    resolution: {integrity: sha512-1KucTHgOvaw/LzCVrEOAyXkr9rQlp0A1HiHRYnSUE9dmb8PvPW7o5sscg+5169r54n3vGlbx6GevTE/Iw/P3AQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
@@ -689,8 +678,8 @@ packages:
     resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.10
-      '@babel/parser': 7.22.11
+      '@babel/code-frame': 7.22.13
+      '@babel/parser': 7.22.14
       '@babel/types': 7.22.11
     dev: true
 
@@ -698,13 +687,13 @@ packages:
     resolution: {integrity: sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.10
+      '@babel/code-frame': 7.22.13
       '@babel/generator': 7.22.10
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-function-name': 7.22.5
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.22.11
+      '@babel/parser': 7.22.14
       '@babel/types': 7.22.11
       debug: 4.3.4
       globals: 11.12.0
@@ -1743,7 +1732,7 @@ packages:
   /@types/babel__core@7.20.1:
     resolution: {integrity: sha512-aACu/U/omhdk15O4Nfb+fHgH/z3QsfQzpnvRZhYhThms83ZnAOZz7zZAWO7mn2yyNQaA4xTO8GLK3uqFU4bYYw==}
     dependencies:
-      '@babel/parser': 7.22.11
+      '@babel/parser': 7.22.14
       '@babel/types': 7.22.11
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
@@ -1759,7 +1748,7 @@ packages:
   /@types/babel__template@7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.22.11
+      '@babel/parser': 7.22.14
       '@babel/types': 7.22.11
     dev: true
 
@@ -1767,6 +1756,10 @@ packages:
     resolution: {integrity: sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==}
     dependencies:
       '@babel/types': 7.22.11
+    dev: true
+
+  /@types/braces@3.0.2:
+    resolution: {integrity: sha512-U5tlMYa0U/2eFTmJgKcPWQOEICP173sJDa6OjHbj5Tv+NVaYcrq2xmdWpNXOwWYGwJu+jER/pfTLdoQ31q8PzA==}
     dev: true
 
   /@types/chai-subset@1.3.3:
@@ -1796,7 +1789,7 @@ packages:
   /@types/hast@2.3.5:
     resolution: {integrity: sha512-SvQi0L/lNpThgPoleH53cdjB3y9zpLlVjRbqB3rH8hx1jiRSBGAhyjV3H+URFjNVRqt2EdYNrbZE5IsGlNfpRg==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
     dev: true
 
   /@types/is-ci@3.0.0:
@@ -1816,7 +1809,13 @@ packages:
   /@types/mdast@3.0.12:
     resolution: {integrity: sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
+    dev: true
+
+  /@types/micromatch@4.0.2:
+    resolution: {integrity: sha512-oqXqVb0ci19GtH0vOA/U2TmHTcRY9kuZl4mqUxe0QmJAlIW13kzhuK5pi1i9+ngav8FjpSb9FVS/GE00GLX1VA==}
+    dependencies:
+      '@types/braces': 3.0.2
     dev: true
 
   /@types/mime@3.0.1:
@@ -1834,7 +1833,7 @@ packages:
   /@types/nlcst@1.0.1:
     resolution: {integrity: sha512-aVIyXt6pZiiMOtVByE4Y0gf+BLm1Cxc4ZLSK8VRHn1CgkO+kXbQwN/EBhQmhPdBMjFJCMBKtmNW2zWQuFywz8Q==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
     dev: true
 
   /@types/node@12.0.2:
@@ -1869,8 +1868,8 @@ packages:
     resolution: {integrity: sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==}
     dev: true
 
-  /@types/unist@2.0.7:
-    resolution: {integrity: sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==}
+  /@types/unist@2.0.8:
+    resolution: {integrity: sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw==}
     dev: true
 
   /@types/yargs-parser@21.0.0:
@@ -2094,8 +2093,8 @@ packages:
       vscode-uri: 2.1.2
     dev: true
 
-  /@vscode/l10n@0.0.14:
-    resolution: {integrity: sha512-/yrv59IEnmh655z1oeDnGcvMYwnEzNzHLgeYcQCkhYX0xBvYWrAuefoiLcPBUkMpJsb46bqQ6Yv4pwTTQ4d3Qg==}
+  /@vscode/l10n@0.0.16:
+    resolution: {integrity: sha512-JT5CvrIYYCrmB+dCana8sUqJEcGB1ZDXNLMQ2+42bW995WmNoenijWMUdZfwmuQUTQcEVVIa2OecZzTYWUW9Cg==}
     dev: true
 
   /acorn-jsx@5.3.2(acorn@8.10.0):
@@ -2246,8 +2245,8 @@ packages:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
 
-  /astro@2.10.14(sass@1.66.1):
-    resolution: {integrity: sha512-02k2DjnI8yGtLCvdCSggvfCTkTWPm9UDgc/XHKdd1K34TSTl3X0A8TTYbASEXvgynk1zInCyOEe3IUDt3Lke+A==}
+  /astro@2.10.15(sass@1.66.1):
+    resolution: {integrity: sha512-7jgkCZexxOX541g2kKHGOcDDUVKYc+sGi87GtLOkbWwTsKqEIp9GU0o7DpKe1rhItm9VVEiHz4uxvMh3wGmJdA==}
     engines: {node: '>=16.12.0', npm: '>=6.14.0'}
     hasBin: true
     peerDependencies:
@@ -2259,12 +2258,12 @@ packages:
       '@astrojs/compiler': 1.8.2
       '@astrojs/internal-helpers': 0.1.2
       '@astrojs/language-server': 1.0.8
-      '@astrojs/markdown-remark': 2.2.1(astro@2.10.14)
+      '@astrojs/markdown-remark': 2.2.1(astro@2.10.15)
       '@astrojs/telemetry': 2.1.1
       '@astrojs/webapi': 2.2.0
       '@babel/core': 7.22.11
       '@babel/generator': 7.22.10
-      '@babel/parser': 7.22.11
+      '@babel/parser': 7.22.14
       '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.22.11)
       '@babel/traverse': 7.22.11
       '@babel/types': 7.22.11
@@ -2297,12 +2296,12 @@ packages:
       ora: 6.3.1
       p-limit: 4.0.0
       path-to-regexp: 6.2.1
-      preferred-pm: 3.0.3
+      preferred-pm: 3.1.1
       prompts: 2.4.2
       rehype: 12.0.1
       semver: 7.5.4
       server-destroy: 1.0.1
-      shiki: 0.14.3
+      shiki: 0.14.4
       string-width: 5.1.2
       strip-ansi: 7.1.0
       tsconfig-resolver: 3.0.1
@@ -2311,7 +2310,7 @@ packages:
       vfile: 5.3.7
       vite: 4.4.9(sass@1.66.1)
       vitefu: 0.2.4(vite@4.4.9)
-      which-pm: 2.0.0
+      which-pm: 2.1.1
       yargs-parser: 21.1.1
       zod: 3.22.2
     transitivePeerDependencies:
@@ -2422,8 +2421,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001523
-      electron-to-chromium: 1.4.503
+      caniuse-lite: 1.0.30001525
+      electron-to-chromium: 1.4.507
       node-releases: 2.0.13
       update-browserslist-db: 1.0.11(browserslist@4.21.10)
     dev: true
@@ -2495,8 +2494,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /caniuse-lite@1.0.30001523:
-    resolution: {integrity: sha512-I5q5cisATTPZ1mc588Z//pj/Ox80ERYDfR71YnvY7raS/NOk8xXlZcB0sF7JdqaV//kOaa6aus7lRfpdnt1eBA==}
+  /caniuse-lite@1.0.30001525:
+    resolution: {integrity: sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==}
     dev: true
 
   /ccount@2.0.1:
@@ -2977,8 +2976,8 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
 
-  /electron-to-chromium@1.4.503:
-    resolution: {integrity: sha512-LF2IQit4B0VrUHFeQkWhZm97KuJSGF2WJqq1InpY+ECpFRkXd8yTIaTtJxsO0OKDmiBYwWqcrNaXOurn2T2wiA==}
+  /electron-to-chromium@1.4.507:
+    resolution: {integrity: sha512-brvPFnO1lu3UYBpBht2qWw9qqhdG4htTjT90/9oOJmxQ77VvTxL9+ghErFqQzgj7n8268ONAmlebqjBR/S+qgA==}
     dev: true
 
   /emmet@2.4.6:
@@ -3742,7 +3741,7 @@ packages:
     resolution: {integrity: sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==}
     dependencies:
       '@types/hast': 2.3.5
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
       hastscript: 7.2.0
       property-information: 6.2.0
       vfile: 5.3.7
@@ -3776,7 +3775,7 @@ packages:
     resolution: {integrity: sha512-4tpQTUOr9BMjtYyNlt0P50mH7xj0Ks2xpo8M943Vykljf99HW6EzulIoJP1N3eKOSScEHzyzi9dm7/cn0RfGwA==}
     dependencies:
       '@types/hast': 2.3.5
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
       ccount: 2.0.1
       comma-separated-tokens: 2.0.3
       hast-util-raw: 7.2.3
@@ -4374,7 +4373,7 @@ packages:
     resolution: {integrity: sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==}
     dependencies:
       '@types/mdast': 3.0.12
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
       unist-util-visit: 4.1.2
     dev: true
 
@@ -4391,7 +4390,7 @@ packages:
     resolution: {integrity: sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==}
     dependencies:
       '@types/mdast': 3.0.12
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
       decode-named-character-reference: 1.0.2
       mdast-util-to-string: 3.2.0
       micromark: 3.2.0
@@ -4486,7 +4485,7 @@ packages:
     resolution: {integrity: sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==}
     dependencies:
       '@types/mdast': 3.0.12
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
       longest-streak: 3.1.0
       mdast-util-phrasing: 3.0.1
       mdast-util-to-string: 3.2.0
@@ -4811,7 +4810,6 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
-    dev: true
 
   /mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
@@ -5321,16 +5319,6 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
-  /preferred-pm@3.0.3:
-    resolution: {integrity: sha512-+wZgbxNES/KlJs9q40F/1sfOd/j7f1O9JaHcW5Dsn3aUUOZg3L2bjpVUcKV2jvtElYfoTuQiNeMfQJ4kwUAhCQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      find-up: 5.0.0
-      find-yarn-workspace-root2: 1.2.16
-      path-exists: 4.0.0
-      which-pm: 2.0.0
-    dev: true
-
   /preferred-pm@3.1.1:
     resolution: {integrity: sha512-CsZgOVLKHifdoRu2y66P1s6oLb2WfT5Njkcgi80I/52FWTTVkWG6z0Z13vPkXC4hsT0nMrYXqX30buH8+D2eRQ==}
     engines: {node: '>=10'}
@@ -5830,8 +5818,8 @@ packages:
     resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
     dev: true
 
-  /shiki@0.14.3:
-    resolution: {integrity: sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==}
+  /shiki@0.14.4:
+    resolution: {integrity: sha512-IXCRip2IQzKwxArNNq1S+On4KPML3Yyn8Zzs/xRgcgOWIr8ntIK3IKzjFPfjy/7kt9ZMjc+FItfqHRBg8b6tNQ==}
     dependencies:
       ansi-sequence-parser: 1.1.1
       jsonc-parser: 3.2.0
@@ -6346,7 +6334,7 @@ packages:
   /unified@10.1.2:
     resolution: {integrity: sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
       bail: 2.0.2
       extend: 3.0.2
       is-buffer: 2.0.5
@@ -6362,45 +6350,45 @@ packages:
   /unist-util-is@5.2.1:
     resolution: {integrity: sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
     dev: true
 
   /unist-util-modify-children@3.1.1:
     resolution: {integrity: sha512-yXi4Lm+TG5VG+qvokP6tpnk+r1EPwyYL04JWDxLvgvPV40jANh7nm3udk65OOWquvbMDe+PL9+LmkxDpTv/7BA==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
       array-iterate: 2.0.1
     dev: true
 
   /unist-util-position@4.0.4:
     resolution: {integrity: sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
     dev: true
 
   /unist-util-stringify-position@3.0.3:
     resolution: {integrity: sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
     dev: true
 
   /unist-util-visit-children@2.0.2:
     resolution: {integrity: sha512-+LWpMFqyUwLGpsQxpumsQ9o9DG2VGLFrpz+rpVXYIEdPy57GSy5HioC0g3bg/8WP9oCLlapQtklOzQ8uLS496Q==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
     dev: true
 
   /unist-util-visit-parents@5.1.3:
     resolution: {integrity: sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
       unist-util-is: 5.2.1
     dev: true
 
   /unist-util-visit@4.1.2:
     resolution: {integrity: sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
       unist-util-is: 5.2.1
       unist-util-visit-parents: 5.1.3
     dev: true
@@ -6457,21 +6445,21 @@ packages:
   /vfile-location@4.1.0:
     resolution: {integrity: sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
       vfile: 5.3.7
     dev: true
 
   /vfile-message@3.1.4:
     resolution: {integrity: sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
       unist-util-stringify-position: 3.0.3
     dev: true
 
   /vfile@5.3.7:
     resolution: {integrity: sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.8
       is-buffer: 2.0.5
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
@@ -6770,19 +6758,19 @@ packages:
       - terser
     dev: true
 
-  /vscode-css-languageservice@6.2.6:
-    resolution: {integrity: sha512-SA2WkeOecIpUiEbZnjOsP/fI5CRITZEiQGSHXKiDQDwLApfKcnLhZwMtOBbIifSzESVcQa7b/shX/nbnF4NoCg==}
+  /vscode-css-languageservice@6.2.7:
+    resolution: {integrity: sha512-Jd8wpIg5kJ15CfrieoEPvu3gGFc36sbM3qXCtjVq5zrnLEX5NhHxikMDtf8AgQsYklXiDqiZLKoBnzkJtRbTHQ==}
     dependencies:
-      '@vscode/l10n': 0.0.14
+      '@vscode/l10n': 0.0.16
       vscode-languageserver-textdocument: 1.0.8
       vscode-languageserver-types: 3.17.3
       vscode-uri: 3.0.7
     dev: true
 
-  /vscode-html-languageservice@5.0.6:
-    resolution: {integrity: sha512-gCixNg6fjPO7+kwSMBAVXcwDRHdjz1WOyNfI0n5Wx0J7dfHG8ggb3zD1FI8E2daTZrwS1cooOiSoc1Xxph4qRQ==}
+  /vscode-html-languageservice@5.0.7:
+    resolution: {integrity: sha512-jX+7/kUXrdOaRT8vqYR/jLxrGDib+Far8I7n/A6apuEl88k+mhIHZPwc6ezuLeiCKUCaLG4b0dqFwjVa7QL3/w==}
     dependencies:
-      '@vscode/l10n': 0.0.14
+      '@vscode/l10n': 0.0.16
       vscode-languageserver-textdocument: 1.0.8
       vscode-languageserver-types: 3.17.3
       vscode-uri: 3.0.7
@@ -6873,6 +6861,14 @@ packages:
 
   /which-pm@2.0.0:
     resolution: {integrity: sha512-Lhs9Pmyph0p5n5Z3mVnN0yWcbQYUAD7rbQUiMsQxOJ3T57k7RFe35SUwWMf7dsbDZks1uOmw4AecB/JMDj3v/w==}
+    engines: {node: '>=8.15'}
+    dependencies:
+      load-yaml-file: 0.2.0
+      path-exists: 4.0.0
+    dev: true
+
+  /which-pm@2.1.1:
+    resolution: {integrity: sha512-xzzxNw2wMaoCWXiGE8IJ9wuPMU+EYhFksjHxrRT8kMT5SnocBPRg69YAMtyV4D12fP582RA+k3P8H9J5EMdIxQ==}
     engines: {node: '>=8.15'}
     dependencies:
       load-yaml-file: 0.2.0


### PR DESCRIPTION
## Changes

Fixes #72. Adds glob support for `@cobalt-ui/plugin-css`’ `modeSelectors` API, allowing you to select certain token IDs.

Also improves the API and updates docs. The old API will still be supported through 1.x.

## How to Review

- Tests should pass

