### PR TITLE
@cobalt-ui/utils@1.2.2

### DIFF
--- a/.changeset/violet-paws-ring.md
+++ b/.changeset/violet-paws-ring.md
@@ -1,5 +1,0 @@
----
-'@cobalt-ui/utils': patch
----
-
-Add getLocalID util

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@cobalt-ui/core": "^1.4.3",
-    "@cobalt-ui/utils": "^1.2.1",
+    "@cobalt-ui/utils": "^1.2.2",
     "chokidar": "^3.5.3",
     "culori": "^3.2.0",
     "dotenv": "^16.3.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
     "test:ts": "tsc --noEmit"
   },
   "dependencies": {
-    "@cobalt-ui/utils": "^1.2.1",
+    "@cobalt-ui/utils": "^1.2.2",
     "@types/culori": "^2.0.0",
     "culori": "^3.2.0"
   },

--- a/packages/plugin-css/package.json
+++ b/packages/plugin-css/package.json
@@ -33,7 +33,7 @@
     "@cobalt-ui/cli": "^1.x"
   },
   "dependencies": {
-    "@cobalt-ui/utils": "^1.2.1",
+    "@cobalt-ui/utils": "^1.2.2",
     "@types/culori": "^2.0.0",
     "@types/mime": "^3.0.1",
     "culori": "^3.2.0",

--- a/packages/plugin-js/package.json
+++ b/packages/plugin-js/package.json
@@ -34,7 +34,7 @@
     "@cobalt-ui/cli": "1.x"
   },
   "dependencies": {
-    "@cobalt-ui/utils": "^1.2.1"
+    "@cobalt-ui/utils": "^1.2.2"
   },
   "devDependencies": {
     "@cobalt-ui/cli": "^1.4.2",

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -31,10 +31,10 @@
   },
   "peerDependencies": {
     "@cobalt-ui/cli": "^1.x",
-    "@cobalt-ui/plugin-css": "^1.4.1"
+    "@cobalt-ui/plugin-css": "^1.x"
   },
   "dependencies": {
-    "@cobalt-ui/utils": "^1.2.1",
+    "@cobalt-ui/utils": "^1.2.2",
     "@types/mime": "^3.0.1",
     "mime": "^3.0.0",
     "svgo": "^3.0.2"

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @cobalt-ui/utils
 
+## 1.2.2
+
+### Patch Changes
+
+- [#104](https://github.com/drwpow/cobalt-ui/pull/104) [`c391da1`](https://github.com/drwpow/cobalt-ui/commit/c391da12ddb342e6bea90197d53052ef6d6fdbfe) Thanks [@drwpow](https://github.com/drwpow)! - Add getLocalID util
+
 ## 1.2.1
 
 ### Patch Changes

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cobalt-ui/utils",
   "description": "Generic codegen utilities",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": {
     "name": "Drew Powers",
     "email": "drew@pow.rs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,7 +202,7 @@ importers:
         specifier: ^1.4.3
         version: link:../core
       '@cobalt-ui/utils':
-        specifier: ^1.2.1
+        specifier: ^1.2.2
         version: link:../utils
       chokidar:
         specifier: ^3.5.3
@@ -248,7 +248,7 @@ importers:
   packages/core:
     dependencies:
       '@cobalt-ui/utils':
-        specifier: ^1.2.1
+        specifier: ^1.2.2
         version: link:../utils
       '@types/culori':
         specifier: ^2.0.0
@@ -273,7 +273,7 @@ importers:
   packages/plugin-css:
     dependencies:
       '@cobalt-ui/utils':
-        specifier: ^1.2.1
+        specifier: ^1.2.2
         version: link:../utils
       '@types/culori':
         specifier: ^2.0.0
@@ -310,7 +310,7 @@ importers:
   packages/plugin-js:
     dependencies:
       '@cobalt-ui/utils':
-        specifier: ^1.2.1
+        specifier: ^1.2.2
         version: link:../utils
     devDependencies:
       '@cobalt-ui/cli':
@@ -332,7 +332,7 @@ importers:
   packages/plugin-sass:
     dependencies:
       '@cobalt-ui/utils':
-        specifier: ^1.2.1
+        specifier: ^1.2.2
         version: link:../utils
       '@types/mime':
         specifier: ^3.0.1


### PR DESCRIPTION
## Changes

Release `@cobalt-ui/utils` separately so changesets stops trying to push major versions

## How to Review

N/A
