### PR TITLE
Improve utils build command

### DIFF
--- a/packages/utils/.npmignore
+++ b/packages/utils/.npmignore
@@ -1,2 +1,2 @@
+test/
 tsconfig.json
-*.test.*

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,12 +10,13 @@
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "del dist && tsc",
     "dev": "tsc -w",
     "test": "vitest run"
   },
   "devDependencies": {
     "@types/node": "^20.5.0",
+    "del-cli": "^4.0.1",
     "vitest": "^0.34.2"
   }
 }

--- a/packages/utils/test/object.test.ts
+++ b/packages/utils/test/object.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from 'vitest';
-import {cloneDeep} from './object.js';
+import {cloneDeep} from '../src/object.js';
 
 describe('cloneDeep', () => {
   test('creates deep copies of all types', () => {

--- a/packages/utils/test/string.test.ts
+++ b/packages/utils/test/string.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from 'vitest';
-import {camelize, kebabinate, objKey} from './string.js';
+import {camelize, kebabinate, objKey} from '../src/string.js';
 
 describe('camelize', () => {
   test('basic', () => {

--- a/packages/utils/test/token.test.ts
+++ b/packages/utils/test/token.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from 'vitest';
-import {getAliasID, getLocalID, isAlias} from './token.js';
+import {getAliasID, getLocalID, isAlias} from '../src/token.js';
 
 describe('getAliasID', () => {
   test('returns unwrapped ID for valid ID', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,6 +368,9 @@ importers:
       '@types/node':
         specifier: ^20.5.0
         version: 20.5.0
+      del-cli:
+        specifier: ^4.0.1
+        version: 4.0.1
       vitest:
         specifier: ^0.34.2
         version: 0.34.2


### PR DESCRIPTION
## Changes

- Adds `del-cli` to `@cobalt-ui/utils` to clean the build directory every publish
- Moves tests to `tests/` folder to be consistent with other packages (and make it harder to accidentally publish test files)

## How to Review

- monorepo chore; no actual code changes to review
