### PR TITLE
Add Google verification to docs site

### DIFF
--- a/docs/public/googlec446be7f016b2162.html
+++ b/docs/public/googlec446be7f016b2162.html
@@ -1,0 +1,1 @@
+google-site-verification: googlec446be7f016b2162.html


### PR DESCRIPTION
## Changes

For Search Console. This site **does not** use Google Analytics for privacy concerns. But for tracking SEO from Google this verifies site ownership.

## How to Review

- Docs-only change
