### PR TITLE
[docs] Fix homepage title

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   },
   transformHead(context) {
     return [
-      ['meta', {name: 'og:title', content: context.pageData.frontmatter.title ? `${context.pageData.frontmatter.title} | Cobalt` : `Cobalt: CI for your Design Tokens`}],
+      ['meta', {name: 'og:title', content: context.pageData.frontmatter.title ? `${context.pageData.frontmatter.title} | Cobalt` : 'Cobalt: CI for your Design Tokens'}],
       ['meta', {name: 'og:description', content: context.pageData.frontmatter.description || 'Use Design Tokens Format Module tokens to generate CSS, Sass, JS/TS, universal JSON, and more.'}],
       ['meta', {name: 'og:image', content: `${HOSTNAME}/social.png`}],
       ['meta', {name: 'twitter:card', content: 'summary_large_image'}],

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,8 @@
 # https://vitepress.dev/reference/default-theme-home-page
 layout: home
 
-title: 'Cobalt: CI for your design tokens'
+title: Cobalt
+titleTemplate: CI for Design Tokens
 
 hero:
   name: Cobalt


### PR DESCRIPTION
## Changes

Homepage title was showing `Cobalt: CI for your design tokens | Cobalt` when it can omit the suffix (should just use default title). Docs-only change; no code changes.

## How to Review

N/A
