### PR TITLE
handle empty mode objects

### DIFF
--- a/.changeset/popular-zebras-develop.md
+++ b/.changeset/popular-zebras-develop.md
@@ -1,0 +1,5 @@
+---
+'@cobalt-ui/plugin-js': patch
+---
+
+pluginJS: properly serialize output when $extensions.mode is an empty object

--- a/packages/plugin-js/src/index.ts
+++ b/packages/plugin-js/src/index.ts
@@ -32,6 +32,10 @@ interface TSResult {
   modes: {[id: string]: string | TSResult['modes']};
 }
 
+function isEmptyObject(obj: object): boolean {
+  return Object.keys(obj as object).length === 0;
+}
+
 const tokenTypes: Record<ParsedToken['$type'], string> = {
   color: 'ParsedColorToken',
   fontFamily: 'ParsedFontFamilyToken',
@@ -67,6 +71,8 @@ export function serializeJS(value: unknown, options?: {comments?: Record<string,
     throw new Error(`Cannot serialize function ${value}`);
   }
   if (typeof value === 'object') {
+    if (isEmptyObject(value)) return '{}';
+
     return `{
 ${Object.entries(value)
   .map(([k, v]) => {
@@ -98,6 +104,8 @@ export function serializeTS(value: unknown, options?: {indentLv?: number}): stri
     throw new Error(`Cannot serialize function ${value}`);
   }
   if (typeof value === 'object') {
+    if (isEmptyObject(value)) return 'Record<string, never>';
+
     return `{
 ${Object.entries(value)
   .map(([k, v]) => `${indent(objKey(k), indentLv + 1)}: ${serializeTS(v, {indentLv: indentLv + 1})}`)

--- a/packages/plugin-js/test/color/tokens.json
+++ b/packages/plugin-js/test/color/tokens.json
@@ -19,7 +19,10 @@
       "90": {"$value": "#72cce5"},
       "100": {"$value": "#89eff1"}
     },
-    "white": {"$value": "#ffffff"}
+    "white": {
+      "$value": "#ffffff",
+      "$extensions": {"mode": {}}
+    }
   },
   "ui": {
     "bg": {

--- a/packages/plugin-js/test/color/want.d.ts
+++ b/packages/plugin-js/test/color/want.d.ts
@@ -39,12 +39,13 @@ export declare const meta: {
   'color.blue.80': ParsedColorToken;
   'color.blue.90': ParsedColorToken;
   'color.blue.100': ParsedColorToken;
-  'color.white': ParsedColorToken;
+  'color.white': ParsedColorToken & { $extensions: { mode: typeof modes['color.white'] } };
   'ui.bg': ParsedColorToken & { $extensions: { mode: typeof modes['ui.bg'] } };
   'ui.fg': ParsedColorToken & { $extensions: { mode: typeof modes['ui.fg'] } };
 };
 
 export declare const modes: {
+  'color.white': Record<string, never>;
   'ui.bg': {
     light: ParsedColorToken['$value'];
     dark: ParsedColorToken['$value'];

--- a/packages/plugin-js/test/color/want.js
+++ b/packages/plugin-js/test/color/want.js
@@ -221,6 +221,9 @@ export const meta = {
   'color.white': {
     _original: {
       $value: '#ffffff',
+      $extensions: {
+        mode: {},
+      },
     },
     _group: {
       id: 'color',
@@ -233,6 +236,9 @@ export const meta = {
     id: 'color.white',
     $type: 'color',
     $value: '#ffffff',
+    $extensions: {
+      mode: {},
+    },
   },
   'ui.bg': {
     _original: {
@@ -291,6 +297,7 @@ export const meta = {
 };
 
 export const modes = {
+  'color.white': {},
   'ui.bg': {
     light: '#ffffff',
     dark: '#00193f',

--- a/packages/plugin-js/test/color/want.json
+++ b/packages/plugin-js/test/color/want.json
@@ -213,7 +213,10 @@
     },
     "color.white": {
       "_original": {
-        "$value": "#ffffff"
+        "$value": "#ffffff",
+        "$extensions": {
+          "mode": {}
+        }
       },
       "_group": {
         "id": "color",
@@ -225,7 +228,10 @@
       },
       "id": "color.white",
       "$type": "color",
-      "$value": "#ffffff"
+      "$value": "#ffffff",
+      "$extensions": {
+        "mode": {}
+      }
     },
     "ui.bg": {
       "_original": {
@@ -283,6 +289,7 @@
     }
   },
   "modes": {
+    "color.white": {},
     "ui.bg": {
       "light": "#ffffff",
       "dark": "#00193f"


### PR DESCRIPTION
## Changes

Fixes #165 

## How to Review

Copy only the changes from _packages/plugin-js/test/color/tokens.json_ into the main branch, run the tests, and observe that the output of the color test is invalid due to the extra commas that get inserted. Then observe that the tests on this branch pass thanks to the additional serialization logic to handle empty objects.
