### PR TITLE
Ensure alias conform example

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -121,8 +121,10 @@ color:
       '9':
         $value: '#002155'
   semantic:
-    action: '{color.base.blue.5}'
-    textColor: '{color.base.gray.9}'
+    action:
+      $value: '{color.base.blue.5}'
+    textColor:
+      $value: '{color.base.gray.9}'
 fontStack:
   $type: fontFamily
   sansSerif:

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -52,8 +52,8 @@ Next, we’ll create a `tokens.json` file in the root of our project (or `tokens
       }
     },
     "semantic": {
-      "action": "{color.base.blue.5}",
-      "textColor": "{color.base.gray.9}"
+      "action": {"$value": "{color.base.blue.5}"},
+      "textColor": {"$value": "{color.base.gray.9}"}
     }
   },
   "fontStack": {

--- a/packages/cli/test/build.test.js
+++ b/packages/cli/test/build.test.js
@@ -50,4 +50,15 @@ describe('co build', () => {
       expect(Object.keys(builtTokens.meta).length).toBe(34);
     });
   });
+
+  describe('docs examples', () => {
+    it('Guides: Getting Started', async () => {
+      const cwd = new URL('./fixtures/build-docs-examples/guides/getting-started', import.meta.url);
+      await execa('node', [`../../${cmd}`, 'build'], {cwd});
+
+      const builtTokens = await import('./fixtures/build-docs-examples/guides/getting-started/tokens/index.js');
+
+      expect(Object.keys(builtTokens.meta).length).toBe(29);
+    });
+  });
 });

--- a/packages/cli/test/fixtures/build-docs-examples/guides/getting-started/tokens.config.mjs
+++ b/packages/cli/test/fixtures/build-docs-examples/guides/getting-started/tokens.config.mjs
@@ -1,0 +1,9 @@
+import pluginCSS from '../../../../../../plugin-css/dist/index.js';
+import pluginJS from '../../../../../../plugin-js/dist/index.js';
+
+/** @type import('../../../../../../core').Config */
+export default {
+  tokens: './tokens.json',
+  outDir: './tokens/',
+  plugins: [pluginCSS(/* options */), pluginJS(/* options */)],
+};

--- a/packages/cli/test/fixtures/build-docs-examples/guides/getting-started/tokens.json
+++ b/packages/cli/test/fixtures/build-docs-examples/guides/getting-started/tokens.json
@@ -1,0 +1,50 @@
+{
+  "color": {
+    "$type": "color",
+    "base": {
+      "gray": {
+        "0": {"$value": "#f6f8fa"},
+        "1": {"$value": "#eaeef2"},
+        "2": {"$value": "#d0d7de"},
+        "3": {"$value": "#afb8c1"},
+        "4": {"$value": "#8c959f"},
+        "5": {"$value": "#6e7781"},
+        "6": {"$value": "#57606a"},
+        "7": {"$value": "#424a53"},
+        "8": {"$value": "#32383f"},
+        "9": {"$value": "#24292f"}
+      },
+      "blue": {
+        "0": {"$value": "#ddf4ff"},
+        "1": {"$value": "#b6e3ff"},
+        "2": {"$value": "#80ccff"},
+        "3": {"$value": "#54aeff"},
+        "4": {"$value": "#218bff"},
+        "5": {"$value": "#0969da"},
+        "6": {"$value": "#0550ae"},
+        "7": {"$value": "#033d8b"},
+        "8": {"$value": "#0a3069"},
+        "9": {"$value": "#002155"}
+      }
+    },
+    "semantic": {
+      "action": {"$value": "{color.base.blue.5}"},
+      "textColor": {"$value": "{color.base.gray.9}"}
+    }
+  },
+  "fontStack": {
+    "$type": "fontFamily",
+    "sansSerif": {
+      "$value": ["-apple-system", "BlinkMacSystemFont", "Segoe UI", "Noto Sans", "Helvetica", "Arial", "sans-serif", "Apple Color Emoji", "Segoe UI Emoji"]
+    }
+  },
+  "space": {
+    "$type": "dimension",
+    "xxsmall": {"$value": "2px"},
+    "xsmall": {"$value": "4px"},
+    "small": {"$value": "6px"},
+    "medium": {"$value": "8px"},
+    "large": {"$value": "12px"},
+    "xlarge": {"$value": "16px"}
+  }
+}


### PR DESCRIPTION
# Pull Request

## Changes

Currently the example shown at the ["Getting Started" guide](https://cobalt-ui.pages.dev/guides/getting-started#setup) is not working as the alias definition is not compatible. While the shortcut version of assigning an alias to any key directly is appealing, [it doesn't seem to be specified to that extent](https://design-tokens.github.io/community-group/format/#alias-reference) and is therefore not covered yet. To ease the introduction it is useful if first encountered example in the guides are working correctly as shown.

## How to Review

A test case was added to `build.test.js` which takes on the tokens definitions from the "Guides: Getting Started" section. It is run as part of the regular test suite. For the moment those are manually extracted but later on could be extracted to ease alignment.

## Note

While it would be convenient to reference a token as is with all its properties from `$value` to `$type` as it can reduce the amount of definitions - there might be pending questions in regards to granularity and composition. 

```json
"semantic": {
  "action": "{color.base.blue.5}",
  "textColor": "{color.base.gray.9}"
}
```

In the original example its clear that `color.semantic.action` refers to `color.base.blue.5` which is a color, but it could be that it is used as a `gradient` or other `$type`. Therefore in case aliasing gets extended to allow referencing all/multiple values from the selected JSON path of the tokens like an object rather than just a string - it might be an idea to have the closest `$type` available at the locale scope utilizes if it is available. Like the following:

```json
"semantic": {
  "$type": "gradient",
  "action": "{color.base.blue.5}",
  "textColor": "{color.base.gray.9}"
}
```

Otherwise if at the same level there is no `$type` specified it gets regularly applied from the referenced token. That said this behavior is currently not clarified in the specification so unless there is a larger set of repetitions it might be better for the time being to keep it restricted to single `$value` references only.