### PR TITLE
Align optional Token transforms

### DIFF
--- a/.changeset/modern-flowers-help.md
+++ b/.changeset/modern-flowers-help.md
@@ -1,0 +1,5 @@
+---
+'@cobalt-ui/core': patch
+---
+
+Define base token transform signature

--- a/.changeset/olive-trains-knock.md
+++ b/.changeset/olive-trains-knock.md
@@ -1,0 +1,8 @@
+---
+'@cobalt-ui/plugin-tailwind': patch
+'@cobalt-ui/plugin-sass': patch
+'@cobalt-ui/plugin-css': patch
+'@cobalt-ui/plugin-js': patch
+---
+
+Align plugin token transformers

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,6 +74,20 @@ export interface Config extends Partial<ParseOptions> {
   plugins: Plugin[];
 }
 
+/**
+ * Custom handling of token(s)
+ */
+export type TransformTokenFn = <T extends ParsedToken>(
+  /**
+   * token source on which a transformation is applied
+   */
+  token: T,
+  /**
+   * context at which a transfomration is applied (see `Modes`)
+   */
+  mode?: string,
+) => (typeof token)['$value'] | null;
+
 export default {
   parse,
 };

--- a/packages/plugin-css/src/index.ts
+++ b/packages/plugin-css/src/index.ts
@@ -102,7 +102,7 @@ export default function pluginCSS(options?: Options): Plugin {
       const selectors: string[] = [];
       const colorFormat = options?.colorFormat ?? 'hex';
       for (const token of tokens) {
-        let value: ReturnType<typeof defaultTransformer> | undefined | null = await options?.transform?.(token);
+        let value: ReturnType<typeof defaultTransformer> | undefined | null = options?.transform?.(token);
         if (value === undefined || value === null) {
           value = defaultTransformer(token, {prefix, colorFormat, generateName, tokens});
         }
@@ -165,7 +165,7 @@ export default function pluginCSS(options?: Options): Plugin {
             for (const selector of modeSelector.selectors) {
               if (!selectors.includes(selector)) selectors.push(selector);
               if (!modeVals[selector]) modeVals[selector] = {};
-              let modeVal: ReturnType<typeof defaultTransformer> | undefined | null = await options?.transform?.(token, modeSelector.mode);
+              let modeVal: ReturnType<typeof defaultTransformer> | undefined | null = options?.transform?.(token, modeSelector.mode);
               if (modeVal === undefined || modeVal === null) {
                 modeVal = defaultTransformer(token, {colorFormat, generateName, mode: modeSelector.mode, prefix, tokens});
               }

--- a/packages/plugin-css/src/index.ts
+++ b/packages/plugin-css/src/index.ts
@@ -1,4 +1,4 @@
-import type {BuildResult, ParsedToken, Plugin, ResolvedConfig} from '@cobalt-ui/core';
+import type {BuildResult, Plugin, TransformTokenFn, ResolvedConfig} from '@cobalt-ui/core';
 import {indent, FG_YELLOW, RESET} from '@cobalt-ui/utils';
 import {formatCss} from 'culori';
 import defaultTransformer, {type ColorFormat, toRGB} from './transform/index.js';
@@ -33,8 +33,8 @@ export interface Options {
   embedFiles?: boolean;
   /** generate wrapper selectors around token modes */
   modeSelectors?: ModeSelector[] | LegacyModeSelectors;
-  /** handle different token types */
-  transform?: <T extends ParsedToken>(token: T, mode?: string) => string | undefined | null;
+  /** custom handling of token(s) */
+  transform?: TransformTokenFn;
   /** @deprecated prefix variable names */
   prefix?: string;
   /** enable P3 color enhancement? (default: true) */
@@ -102,7 +102,7 @@ export default function pluginCSS(options?: Options): Plugin {
       const selectors: string[] = [];
       const colorFormat = options?.colorFormat ?? 'hex';
       for (const token of tokens) {
-        let value: ReturnType<typeof defaultTransformer> | undefined | null = options?.transform?.(token);
+        let value: ReturnType<TransformTokenFn> | undefined = options?.transform?.(token);
         if (value === undefined || value === null) {
           value = defaultTransformer(token, {prefix, colorFormat, generateName, tokens});
         }
@@ -165,7 +165,7 @@ export default function pluginCSS(options?: Options): Plugin {
             for (const selector of modeSelector.selectors) {
               if (!selectors.includes(selector)) selectors.push(selector);
               if (!modeVals[selector]) modeVals[selector] = {};
-              let modeVal: ReturnType<typeof defaultTransformer> | undefined | null = options?.transform?.(token, modeSelector.mode);
+              let modeVal: ReturnType<TransformTokenFn> | undefined = options?.transform?.(token, modeSelector.mode);
               if (modeVal === undefined || modeVal === null) {
                 modeVal = defaultTransformer(token, {colorFormat, generateName, mode: modeSelector.mode, prefix, tokens});
               }

--- a/packages/plugin-js/src/index.ts
+++ b/packages/plugin-js/src/index.ts
@@ -168,7 +168,7 @@ export default function pluginJS(options?: Options): Plugin {
       };
       const ts: TSResult = {tokens: {}, meta: {}, modes: {}};
       for (const token of tokens) {
-        let result = await options?.transform?.(token);
+        let result = options?.transform?.(token);
         if (result === undefined || result === null) {
           result = defaultTransformer(token);
         }
@@ -198,7 +198,7 @@ export default function pluginJS(options?: Options): Plugin {
           setToken(js.modes, token.id, {}, options?.deep);
           if (buildTS) setToken(ts.modes, token.id, {}, options?.deep);
           for (const modeName of Object.keys(token.$extensions.mode)) {
-            let modeResult = await options?.transform?.(token, modeName);
+            let modeResult = options?.transform?.(token, modeName);
             if (modeResult === undefined || modeResult === null) {
               modeResult = defaultTransformer(token, modeName);
             }

--- a/packages/plugin-js/src/index.ts
+++ b/packages/plugin-js/src/index.ts
@@ -1,11 +1,12 @@
-import type {BuildResult, Mode, ParsedToken, Plugin, Token} from '@cobalt-ui/core';
+import type {BuildResult, Mode, TransformTokenFn, ParsedToken, Plugin, Token} from '@cobalt-ui/core';
 import {cloneDeep, indent, objKey, set} from '@cobalt-ui/utils';
 
 const JS_EXT_RE = /\.(mjs|js)$/i;
 const JSON_EXT_RE = /\.json$/i;
 const SINGLE_QUOTE_RE = /'/g;
 
-export type TransformFn = (token: ParsedToken, mode?: string) => (typeof token)['$value'];
+/** @deprecated consider `TransformTokenFn` from `@cobault-ui/core` instead */
+export type TransformFn = TransformTokenFn;
 
 export interface Options {
   /** output JS? (default: true) */
@@ -14,8 +15,8 @@ export interface Options {
   json?: boolean | string;
   /** output meta? (default: false) */
   meta?: boolean;
-  /** modify values */
-  transform?: TransformFn;
+  /** custom handling of token(s) */
+  transform?: TransformTokenFn;
   /** nested or flat output (default: false) */
   deep?: boolean;
 }

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -139,7 +139,7 @@ ${cbClose}`
         if (cssPlugin) {
           value = varRef(token.id, {prefix, tokens, generateName});
         } else {
-          value = await options?.transform?.(token);
+          value = options?.transform?.(token);
           if (value === undefined || value === null) {
             value = defaultTransformer(token, {colorFormat});
           }

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -1,4 +1,4 @@
-import type {BuildResult, ParsedToken, ParsedTypographyToken, Plugin, ResolvedConfig} from '@cobalt-ui/core';
+import type {BuildResult, TransformTokenFn, ParsedToken, ParsedTypographyToken, Plugin, ResolvedConfig} from '@cobalt-ui/core';
 import pluginCSS, {
   _INTERNAL_makeNameGenerator,
   type Options as PluginCSSOptions,
@@ -32,8 +32,8 @@ export interface Options {
   indentedSyntax?: boolean;
   /** embed files in CSS? */
   embedFiles?: boolean;
-  /** handle different token types */
-  transform?: <T extends ParsedToken>(token: T, mode?: string) => string | undefined | null;
+  /** custom handling of token(s) */
+  transform?: TransformTokenFn;
   /** transform color */
   colorFormat?: NonNullable<PluginCSSOptions['colorFormat']>;
 }
@@ -135,7 +135,7 @@ ${cbClose}`
 
         output.push(indent(`"${token.id}": (`, 1));
 
-        let value: string | number | undefined | null;
+        let value: ReturnType<TransformTokenFn> | undefined;
         if (cssPlugin) {
           value = varRef(token.id, {prefix, tokens, generateName});
         } else {
@@ -149,7 +149,7 @@ ${cbClose}`
 
         // modes
         for (const modeName of Object.keys((token.$extensions && token.$extensions.mode) || {})) {
-          let modeValue: string | number | undefined | null;
+          let modeValue: ReturnType<TransformTokenFn> | undefined;
           if (cssPlugin) {
             modeValue = varRef(token.id, {tokens, generateName});
           } else {


### PR DESCRIPTION
# Pull Request

## Changes

There is a mixed handling of the (optional) token transformers that can be applied throughout the plugins at the moment. While many share the same behavior there is an individual function signature specified along with internal referring to the respective default transformer. The later can differ based on the case, though for a consistent developer experience it is helpful to ensure an alignment which feels familiar if approaching multiple plugins. Therefore the base signature got added to the `core` package from which it gets referenced.

## Note

In addition to referencing the common function signature there were 2 other aspects considered:
* in some places the `options.transform?.(...)` return was declared to be asynchronous having it being `await`ed - since this was neither captured in the TypeScript function signature nor in the documentation it got omitted for consistency, if wished it might again be added as an alternative output to the synchronous processing
* the `transform` option for the Tailwind plugin wasn't documented yet, though it had a different signature referring to a record of `metadata` rather than the usual `mode` specifier, until it gets documented having it aligned with the others seems more helpful (even without the `mode` as its marked anyway as optional) 
