### PR TITLE
DTFM → DTCG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cobalt
 
-Design token tooling compatible with the [Design Tokens Format Module](https://design-tokens.github.io/community-group/format/). Cobalt can:
+Design token tooling compatible with the [Design Tokens Community Group format (DTCG)](https://design-tokens.github.io/community-group/format/). Cobalt can:
 
 - Parse and validate any valid `tokens.json` file
 - Generate Sass, CSS, TypeScript, and more from `tokens.json`

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -6,7 +6,7 @@ const HOSTNAME = 'https://cobalt-ui.pages.dev';
 /** @see https://vitepress.dev/reference/site-config */
 export default defineConfig({
   title: 'Cobalt',
-  description: 'Tooling to use DTFM Design Tokens anywhere',
+  description: 'Tooling to use DTCG Design Tokens anywhere',
   cleanUrls: true,
   head: [
     ['link', {rel: 'shortcut icon', type: 'image/png', href: '/favicon-32.png'}],
@@ -20,7 +20,7 @@ export default defineConfig({
   transformHead(context) {
     return [
       ['meta', {name: 'og:title', content: context.pageData.frontmatter.title ? `${context.pageData.frontmatter.title} | Cobalt` : 'Cobalt: CI for your Design Tokens'}],
-      ['meta', {name: 'og:description', content: context.pageData.frontmatter.description || 'Use Design Tokens Format Module tokens to generate CSS, Sass, JS/TS, universal JSON, and more.'}],
+      ['meta', {name: 'og:description', content: context.pageData.frontmatter.description || 'Use Design Tokens Community Group tokens to generate CSS, Sass, JS/TS, universal JSON, and more.'}],
       ['meta', {name: 'og:image', content: `${HOSTNAME}/social.png`}],
       ['meta', {name: 'twitter:card', content: 'summary_large_image'}],
     ];

--- a/docs/advanced/about.md
+++ b/docs/advanced/about.md
@@ -4,11 +4,11 @@ title: About Cobalt
 
 # About
 
-Cobalt was created to support the [Design Tokens Format Module (DTFM)](https://designtokens.org) and provide a pluggable, extensible interface for generating code for any platform.
+Cobalt was created to support the [Design Tokens Community Group format (DTCG)](https://designtokens.org) and provide a pluggable, extensible interface for generating code for any platform.
 
 ## Project Goals
 
-1. Support the complete and full [Design Tokens Format Module](https://design-tokens.github.io/community-group/format) spec.
+1. Support the complete and full [Design Tokens Community Group format](https://design-tokens.github.io/community-group/format) spec.
 1. Offer the widest compatiblity possible for any platform.
 1. Support a pluggable and configurable architecture, enabling users to write their own plugins to generate any format.
 

--- a/docs/advanced/node.md
+++ b/docs/advanced/node.md
@@ -4,7 +4,7 @@ title: Cobalt Node.js API
 
 # Node.js API
 
-Cobalt’s Node.js API is for parsing and validating the [Design Tokens Format Module](https://designtokens.org) (DTFM) standard. It can’t output code like the [CLI](/guides/cli) can, but it is a lightweight and fast parser/validator for the DTFM spec that could even be used in client code if desired.
+Cobalt’s Node.js API is for parsing and validating the [Design Tokens Community Group format](https://designtokens.org) (DTCG) standard. It can’t output code like the [CLI](/guides/cli) can, but it is a lightweight and fast parser/validator for the DTCG spec that could even be used in client code if desired.
 
 ## Setup
 

--- a/docs/advanced/plugin-api.md
+++ b/docs/advanced/plugin-api.md
@@ -128,7 +128,7 @@ The `build()` function takes one parameter object with 3 keys:
 | Name        |         Type          | Description                                                 |
 | :---------- | :-------------------: | :---------------------------------------------------------- |
 | `tokens`    |       `Token[]`       | An array of tokens with metadata ([docs](#token-structure)) |
-| `rawSchema` |      `DTFM JSON`      | The original `tokens.json` file, unedited.                  |
+| `rawSchema` |      `DTCG JSON`      | The original `tokens.json` file, unedited.                  |
 | `metadata`  | `Record<string, any>` | (currently unused)                                          |
 
 After running, and formatting your output, the `build()` function should return an array of objects with the following properties:

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -4,7 +4,7 @@ title: Cobalt CLI
 
 # CLI
 
-The Cobalt CLI is the primary way to turn your Design Token Format Module (DTFM) design tokens into code. To install it to your project, run:
+The Cobalt CLI is the primary way to turn your Design Token Community Group (DTCG) design tokens into code. To install it to your project, run:
 
 ```sh
 npm i -D @cobalt-ui/cli
@@ -56,11 +56,11 @@ Be sure to specify a `[path]`!
 
 ## Convert
 
-The **convert** comand is useful for converting a foreign format to DTFM. Currently only converting from the [Style Dictionary token format](https://amzn.github.io/style-dictionary) format is supported.
+The **convert** comand is useful for converting a foreign format to DTCG. Currently only converting from the [Style Dictionary token format](https://amzn.github.io/style-dictionary) format is supported.
 
 ### Style Dictionary Format
 
-To convert from the [Style Dictionary token format](https://amzn.github.io/style-dictionary) to DTFM, run:
+To convert from the [Style Dictionary token format](https://amzn.github.io/style-dictionary) to DTCG, run:
 
 ```sh
 npx co convert [input] --out [output]

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -200,7 +200,7 @@ You can also change any settings in `tokens.config.mjs` ([docs](/advanced/config
 
 This covers the basics, but there’s a lot more you can do with your design tokens:
 
-- [Learn about the DTFM format](/guides/tokens)
+- [Learn about the DTCG format](/guides/tokens)
 - [Learn about Modes](/guides/modes) (unique to Cobalt!)
 - See additional integrations:
   - [CSS](/integrations/css)

--- a/docs/guides/tokens.md
+++ b/docs/guides/tokens.md
@@ -4,11 +4,11 @@ title: tokens.json Manifest
 
 # tokens.json
 
-Your `tokens.json` (or `tokens.yaml`) file is a complete manifest of all your design tokens. It follows the [Design Token Format Module (DTFM)](https://www.w3.org/community/design-tokens/), an official standard for describing design tokens.
+Your `tokens.json` (or `tokens.yaml`) file is a complete manifest of all your design tokens. It follows the [Design Token Community Group format (DTCG)](https://www.w3.org/community/design-tokens/), an official standard for describing design tokens.
 
-The format is currently in draft, and being developed by hundreds of design leaders that work at Figma, Adobe, Salesforce, Google, Amazon, Microsoft, Zeplin, Supernova, and more! But despite it still being a draft, it’s still a robust format and is becoming the de-facto standard for design tokens, and many popular design systems [like GitHub Primer](https://primer.style/) either have switched to DTFM or are planning to in the near future.
+The format is currently in draft, and being developed by hundreds of design leaders that work at Figma, Adobe, Salesforce, Google, Amazon, Microsoft, Zeplin, Supernova, and more! But despite it still being a draft, it’s still a robust format and is becoming the de-facto standard for design tokens, and many popular design systems [like GitHub Primer](https://primer.style/) either have switched to DTCG or are planning to in the near future.
 
-## DTFM Format
+## DTCG Format
 
 The basic design token consists of a simple JSON object with `$type` and `$value` (required), as well as an optional `$description` (highly-recommended to use to describe the token’s purpose, as well as usage instructions).
 
@@ -95,7 +95,7 @@ And in addition to these, you can also [group tokens](/tokens/group) in any hier
 
 ### Cobalt extensions
 
-Cobalt **is NOT** its own format; it is an implementation of DTFM as close to the spec as possible. However, just for quality of life, Cobalt supports a superset to DTFM, allowing:
+Cobalt **is NOT** its own format; it is an implementation of DTCG as close to the spec as possible. However, just for quality of life, Cobalt supports a superset to DTCG, allowing:
 
 - [Addition of a Link token for assets](/tokens/link)
 - YAML is supported in addition to JSON
@@ -109,7 +109,7 @@ Any other deviations are considered unintentional. Please [file an issue](https:
 
 ## JSON or YAML?
 
-Though the original [DTFM spec](https://design-tokens.github.io/community-group/format/) (and most examples) use JSON, Cobalt supports YAML equally well since it’s a 1:1 translation. But since YAML is an easier format to read and write, you may prefer it (the Cobalt maintainers do!). Wherever you see mention of `tokens.json`, know that Cobalt supports `tokens.yaml` equally well; the former is just used as the common term for simplicity.
+Though the original [DTCG spec](https://design-tokens.github.io/community-group/format/) (and most examples) use JSON, Cobalt supports YAML equally well since it’s a 1:1 translation. But since YAML is an easier format to read and write, you may prefer it (the Cobalt maintainers do!). Wherever you see mention of `tokens.json`, know that Cobalt supports `tokens.yaml` equally well; the former is just used as the common term for simplicity.
 
 _Tip: [Boop](https://boop.okat.best/) is a simple, secure tool to convert JSON to YAML in a snap._
 
@@ -132,7 +132,7 @@ Note that this will flatten all tokens into one manifest, so you’ll have to ha
 
 ## Naming / organization
 
-Organization is completely up to you! The DTFM spec allows infinite nesting, and lets you name tokens anything, with the following exceptions:
+Organization is completely up to you! The DTCG spec allows infinite nesting, and lets you name tokens anything, with the following exceptions:
 
 - Token names or group names can’t …
   - … contain dots (`.`). These are reserved for shorthand IDs (e.g. `color.base.blue.500`).
@@ -152,4 +152,4 @@ Based on looking at dozens of design systems, here are a few tips and common pat
 
 ## Further Reading
 
-- [The official DTFM specification](https://design-tokens.github.io/community-group/format/)
+- [The official DTCG specification](https://design-tokens.github.io/community-group/format/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ titleTemplate: CI for Design Tokens
 hero:
   name: Cobalt
   text: CI for Design Tokens
-  tagline: Use Design Tokens Format Module tokens to generate CSS, Sass, JS/TS, universal JSON, and more.
+  tagline: Use Design Tokens Community Group format tokens to generate CSS, Sass, JS/TS, universal JSON, and more.
   actions:
     - theme: brand
       text: Get Started
@@ -17,7 +17,7 @@ hero:
       text: View on GitHub
       link: https://github.com/drwpow/cobalt-ui
 features:
-  - title: Supports Design Tokens Format Module
+  - title: Supports DTCG format
     details: Use the universal design token standard for the widest compatibility and no vendor lock-in
   - title: Pluggable & customizable
     details: Written from the ground-up to power your own custom design tooling

--- a/docs/integrations/css.md
+++ b/docs/integrations/css.md
@@ -4,7 +4,7 @@ title: CSS Integration
 
 # CSS Integration
 
-Generate CSS variables from your Design Tokens Format Module (DTFM) tokens.
+Generate CSS variables from your Design Tokens Community Group (DTCG) tokens.
 
 This plugin generates CSS variables for dynamic, flexible theming that supports modes and gives you the full range of what CSS can do.
 

--- a/docs/integrations/figma.md
+++ b/docs/integrations/figma.md
@@ -4,9 +4,9 @@ title: Figma Integration
 
 # Figma Integration
 
-Because Figma doesn’t have a way to export the [Design Tokens Format Module (DTFM)](https://designtokens.org) directly, you’ll need a plugin to export your styles to the DTFM format.
+Because Figma doesn’t have a way to export the [Design Tokens Community Group format (DTCG)](https://designtokens.org) directly, you’ll need a plugin to export your styles to the DTCG format.
 
-The plugin we recommend for now is [Tokens Studio for Figma](https://tokens.studio). Though it doesn’t support DTFM directly either, it does allow you to export your design tokens in a format Cobalt can read.
+The plugin we recommend for now is [Tokens Studio for Figma](https://tokens.studio). Though it doesn’t support DTCG directly either, it does allow you to export your design tokens in a format Cobalt can read.
 
 ::: info
 
@@ -42,7 +42,7 @@ Once your sync method is set up, it should be a snap to re-export that `tokens.j
 | [Border width](https://docs.tokens.studio/available-tokens/border-width-tokens)   |    ✅     | Converted to [Dimension](/tokens/dimension).                                                                                                           |
 | [Shadow](https://docs.tokens.studio/available-tokens/shadow-tokens)               |    ✅     | Basically equivalent to [Shadow](/tokens/shadow).                                                                                                      |
 | [Opacity](https://docs.tokens.studio/available-tokens/opacity-tokens)             |    ✅     | Converted to [Number](/tokens/number)                                                                                                                  |
-| [Typography](https://docs.tokens.studio/available-tokens/typography-tokens)       |    ✅     | Basically equivalent to [Typography](/tokens/typography). **Text decoration** and **Text Case** must be flattened as there is no DTFM spec equivalent. |
+| [Typography](https://docs.tokens.studio/available-tokens/typography-tokens)       |    ✅     | Basically equivalent to [Typography](/tokens/typography). **Text decoration** and **Text Case** must be flattened as there is no DTCG spec equivalent. |
 | [Asset](https://docs.tokens.studio/available-tokens/asset-tokens)                 |    ❌     | TODO. Cobalt supports [Link](/tokens/link), which should be an equivalent.                                                                             |
 | [Composition](https://docs.tokens.studio/available-tokens/composition-tokens)     |    ❌     | Unsupported because this is a paid feature.                                                                                                            |
 | [Dimension](https://docs.tokens.studio/available-tokens/dimension-tokens)         |    ✅     | Direct equivalent to [Dimension](/tokens/dimension).                                                                                                   |
@@ -50,5 +50,5 @@ Once your sync method is set up, it should be a snap to re-export that `tokens.j
 
 #### Notes
 
-- **Duration** and **Cubic Bézier** types aren’t supported by Tokens Studio (because Figma currently doesn’t support animations). So to use those types you’ll need to convert your tokens into DTFM.
+- **Duration** and **Cubic Bézier** types aren’t supported by Tokens Studio (because Figma currently doesn’t support animations). So to use those types you’ll need to convert your tokens into DTCG.
 - Though Cobalt preserves your [Token Sets](https://docs.tokens.studio/themes/token-sets), which means most aliases will work, Token Studio’s [Advanced Themes](https://docs.tokens.studio/themes/themes-pro) is a paid feature and is therefore not supported. Though you could manually upconvert Token Studio themes to [modes](/guides/modes).

--- a/docs/integrations/js.md
+++ b/docs/integrations/js.md
@@ -4,7 +4,7 @@ title: JS + TS Integration
 
 # JavaScript + TypeScript Integration
 
-Generate JavaScript (with TypeScript declarations) from your Design Tokens Format Module (DTFM) tokens.
+Generate JavaScript (with TypeScript declarations) from your Design Tokens Community Group (DTCG) tokens.
 
 ## Setup
 

--- a/docs/integrations/json.md
+++ b/docs/integrations/json.md
@@ -4,7 +4,7 @@ title: JSON Integration
 
 # JSON + Native App Integration
 
-Generate universal JSON from your Design Tokens Format Module (DTFM) tokens. This is usable by any platform, any language (provided you do a small amount of JSON parsing).
+Generate universal JSON from your Design Tokens Community Group (DTCG) tokens. This is usable by any platform, any language (provided you do a small amount of JSON parsing).
 
 ## Setup
 
@@ -61,7 +61,7 @@ You’ll get a generated `./tokens/tokens.json` file with the following structur
 
 Usage will vary depending on the platform and language, but here are a few examples:
 
-- [Simplifying iOS Apps Design with Design Tokens](https://blogs.halodoc.io/simplifying-ios-app-design-with-design-tokens/) (this blog post uses Style Dictonary JSON, but the same ideas apply to DTFM JSON)
+- [Simplifying iOS Apps Design with Design Tokens](https://blogs.halodoc.io/simplifying-ios-app-design-with-design-tokens/) (this blog post uses Style Dictonary JSON, but the same ideas apply to DTCG JSON)
 
 ## Config
 

--- a/docs/integrations/sass.md
+++ b/docs/integrations/sass.md
@@ -4,7 +4,7 @@ title: Sass Integration
 
 # Sass Integration
 
-Generate `.scss` and `.sass` from your Design Tokens Format Module (DTFM) tokens.
+Generate `.scss` and `.sass` from your Design Tokens Community Group (DTCG) tokens.
 
 ## Setup
 

--- a/docs/integrations/style-dictionary.md
+++ b/docs/integrations/style-dictionary.md
@@ -4,7 +4,7 @@ title: Style Dictionary Integration
 
 # Style Dictionary Integration
 
-You can migrate your [Style Dictionary](https://amzn.github.io/style-dictionary) tokens to the Design Tokens Format Module (DTFM) standard by running the following command (granted you have [the CLI installed](/guides/cli)):
+You can migrate your [Style Dictionary](https://amzn.github.io/style-dictionary) tokens to the Design Tokens Community Group (DTCG) standard by running the following command (granted you have [the CLI installed](/guides/cli)):
 
 ```bash
 npx co convert style-dictionary-tokens.json --out tokens.json
@@ -13,19 +13,19 @@ npx co convert style-dictionary-tokens.json --out tokens.json
 After running `npx co convert` it’s not recommended to keep using the Style Dictionary format.
 
 ::: warning
-This is **NOT** a perfect conversion. This is only meant to do most of the work of migrating to DTFM, but you’ll still have to do some clean up and migrate the parts that weren’t able to be converted.
+This is **NOT** a perfect conversion. This is only meant to do most of the work of migrating to DTCG, but you’ll still have to do some clean up and migrate the parts that weren’t able to be converted.
 :::
 
-## Why convert to DTFM?
+## Why convert to DTCG?
 
 ::: tip
 
-Only you can decide what’s best, and don’t fix your design tooling if it isn’t broken! Only switch to DTFM if it makes sense for your project.
+Only you can decide what’s best, and don’t fix your design tooling if it isn’t broken! Only switch to DTCG if it makes sense for your project.
 
 :::
 
-There are reasons to switch from Style Dictionary to DTFM. While Style Dictionary is a powerful and flexible tool, it also requires more configuration and maintenance than DTFM does. For example, Style Dictionary requires you place all your colors underneath a top-level `color` group. If you want to reference colors elsewhere, you’ll have to configure all your transformers to look for them. The same applies for `size` and `time` tokens.
+There are reasons to switch from Style Dictionary to DTCG. While Style Dictionary is a powerful and flexible tool, it also requires more configuration and maintenance than DTCG does. For example, Style Dictionary requires you place all your colors underneath a top-level `color` group. If you want to reference colors elsewhere, you’ll have to configure all your transformers to look for them. The same applies for `size` and `time` tokens.
 
-Further, Style Dictionary is missing more advanced features like `gradient`, `typography`, and `shadow` tokens from the DTFM spec, to name a few (and adding them results in nonstandard usage that would be improved by opting for a standard that supports them out-of-the-box).
+Further, Style Dictionary is missing more advanced features like `gradient`, `typography`, and `shadow` tokens from the DTCG spec, to name a few (and adding them results in nonstandard usage that would be improved by opting for a standard that supports them out-of-the-box).
 
-While Style Dictionary was a significant trailblazer in managing design tokens and was the first mature library to accomplish this elegantly, the new DTFM spec is being designed to replace the Style Dictionary format by improving on its flaws. In fact, DTFM is more influenced by Style Dictionary than any other format, so rest assured that while migrating can be hard work, the goal of DTFM is to support all of Style Dictionary’s functionality and then some.
+While Style Dictionary was a significant trailblazer in managing design tokens and was the first mature library to accomplish this elegantly, the new DTCG spec is being designed to replace the Style Dictionary format by improving on its flaws. In fact, DTCG is more influenced by Style Dictionary than any other format, so rest assured that while migrating can be hard work, the goal of DTCG is to support all of Style Dictionary’s functionality and then some.

--- a/docs/tokens/custom.md
+++ b/docs/tokens/custom.md
@@ -4,7 +4,7 @@ title: Custom Tokens
 
 # Custom Tokens
 
-Any token type currently not part of the Design Token Format Module (DTFM) can be created as a custom token.
+Any token type currently not part of the Design Token Community Group format (DTCG) can be created as a custom token.
 
 However, most Cobalt plugins will throw an error on an unknown type unless you write code that can handle it. The CSS and Sass plugins have a `transformer` option for you to do this.
 

--- a/examples/github/README.md
+++ b/examples/github/README.md
@@ -1,6 +1,6 @@
 # Cobalt Example: GitHub Primer
 
-As of 2023, [GitHub Primer](https://primer.style/) converted to the DTFM format! 🎉. This examples contains **much of Primer’s source as-written** (but with some cleanup, much of the internal details removed, and an example of using with Cobalt). All design tokens and icons in this folder are © GitHub.
+As of 2023, [GitHub Primer](https://primer.style/) converted to the DTCG format! 🎉. This examples contains **much of Primer’s source as-written** (but with some cleanup, much of the internal details removed, and an example of using with Cobalt). All design tokens and icons in this folder are © GitHub.
 
 **Contents**:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # Cobalt UI
 
-CLI for managing [Design Tokens Format Module](https://designtokens.org) token manifests (`tokens.json`) and generating code for any platform via plugins.
+CLI for managing [Design Tokens Community Group (DTCG)](https://designtokens.org) token manifests (`tokens.json`) and generating code for any platform via plugins.
 
 ## Usage
 
@@ -38,7 +38,7 @@ All CLI commands require a [config](/docs/reference/config/) to work properly, w
 | `bundle --out [path]`         | Bundle multiple `tokens.json` files into one, e.g. `co bundle --out path/to/output.json`. Can output `.json` or `.yaml`. Requires [multiple schemas set in config](https://cobalt-ui.pages.dev/docs/reference/config/#loading-multiple-schemas) |
 | `check [path]`                | Validate a `tokens.json` file and check for errors. This won’t output any files.                                                                                                                                                                |
 | `init`                        | Create a starter `tokens.json` file.                                                                                                                                                                                                            |
-| `convert [path] --out [path]` | Convert a [Style Dictionary](https://amzn.github.io/style-dictionary) JSON file to DTFM ([docs](https://cobalt-ui.pages.dev/docs/integrations/style-dictionary))                                                                                |
+| `convert [path] --out [path]` | Convert a [Style Dictionary](https://amzn.github.io/style-dictionary) JSON file to DTCG ([docs](https://cobalt-ui.pages.dev/docs/integrations/style-dictionary))                                                                                |
 
 ## Plugins
 

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -252,7 +252,7 @@ function showHelp() {
     init            Create a starter tokens.json file
     bundle          Combine multiple tokens schemas into one
       --out [path]  Specify bundled tokens.json output
-    convert [file]  Convert Style Dictionary format to DTFM
+    convert [file]  Convert Style Dictionary format to DTCG
       --out [path]  Specify converted tokens.json output
 
   [options]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cobalt-ui/cli",
-  "description": "CLI for managing design tokens using the Design Tokens Format Module (DTFM) standard and generating code for any platform via plugins.",
+  "description": "CLI for managing design tokens using the Design Tokens Community Group (DTCG) standard and generating code for any platform via plugins.",
   "version": "1.6.2",
   "author": {
     "name": "Drew Powers",
@@ -8,8 +8,8 @@
   },
   "keywords": [
     "design tokens",
+    "design tokens community group",
     "design tokens format module",
-    "dtfm",
     "dtcg",
     "cli",
     "w3c design tokens",

--- a/packages/cli/src/convert.ts
+++ b/packages/cli/src/convert.ts
@@ -12,7 +12,7 @@ export interface ConvertResult {
 
 const DURATION_RE = /^[0-9]+(\.[0-9]+)?(s|ms)$/;
 
-/** Convert a Style Dictionary format into DTFM. Or die trying. */
+/** Convert a Style Dictionary format into DTCG. Or die trying. */
 export default function convert(input: any): ConvertResult {
   const errors: string[] = [];
   const warnings: string[] = [];

--- a/packages/cli/test/convert.test.js
+++ b/packages/cli/test/convert.test.js
@@ -6,7 +6,7 @@ import {describe, expect, it} from 'vitest';
 const cmd = '../../../bin/cli.js';
 
 describe('convert', () => {
-  it('converts Style Dictionary → DTFM', async () => {
+  it('converts Style Dictionary → DTCG', async () => {
     const cwd = new URL('./fixtures/style-dictionary/', import.meta.url);
     await execa('node', [cmd, 'convert', 'tokens.json', '-o', 'given.json'], {cwd});
     expect(fs.readFileSync(new URL('given.json', cwd), 'utf8')).toMatchFileSnapshot(fileURLToPath(new URL('want.json', cwd)));

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @cobalt-ui/core
 
-Parser/validator for the [Design Tokens Format Module](https://designtokens.org) (DTFM) standard.
+Parser/validator for the [Design Tokens Community Group](https://designtokens.org) (DTCG) standard.
 
 For the CLI, use `@cobalt-ui/cli`.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cobalt-ui/core",
-  "description": "Parser/validator for the Design Tokens Format Module (DTFM) standard.",
+  "description": "Parser/validator for the Design Tokens Community Group (DTCG) standard.",
   "version": "1.6.1",
   "author": {
     "name": "Drew Powers",
@@ -8,8 +8,9 @@
   },
   "keywords": [
     "design tokens",
+    "design tokens community group",
     "design tokens format module",
-    "dtfm",
+    "dtcg",
     "cli",
     "w3c design tokens",
     "design system",

--- a/packages/core/src/parse/tokens-studio.ts
+++ b/packages/core/src/parse/tokens-studio.ts
@@ -1,7 +1,7 @@
 /**
  * Handle format for Tokens Studio for Figma
  * This works by first converting the Tokens Studio format
- * into an equivalent DTFM result, then parsing that result
+ * into an equivalent DTCG result, then parsing that result
  */
 import {getAliasID, isAlias} from '@cobalt-ui/utils';
 import type {GradientStop, Group, Token} from '../token.js';
@@ -9,12 +9,12 @@ import type {GradientStop, Group, Token} from '../token.js';
 export function convertTokensStudioFormat(rawTokens: Record<string, unknown>): {errors?: string[]; warnings?: string[]; result: Group} {
   const errors: string[] = [];
   const warnings: string[] = [];
-  const dtfmTokens: Group = {};
+  const dtcgTokens: Group = {};
 
   function addToken(value: Token, path: string[]): void {
     const parts = [...path];
     const id = parts.pop()!;
-    let tokenNode = dtfmTokens;
+    let tokenNode = dtcgTokens;
     for (const p of parts) {
       if (!(p in tokenNode)) tokenNode[p] = {};
       tokenNode = tokenNode[p] as Group;
@@ -188,7 +188,7 @@ export function convertTokensStudioFormat(rawTokens: Record<string, unknown>): {
           }
           case 'typography': {
             // fortunately, the Tokens Studio spec is inconsistent with their "typography" tokens
-            // in that they match DTFM (even though `fontFamilies` [sic] tokens exist)
+            // in that they match DTCG (even though `fontFamilies` [sic] tokens exist)
 
             // unfortunately, `textCase` and `textDecoration` are special and have to be flattened
             if (!!v.value && typeof v.value === 'object') {
@@ -234,7 +234,7 @@ export function convertTokensStudioFormat(rawTokens: Record<string, unknown>): {
   return {
     errors: errors.length ? errors : undefined,
     warnings: warnings.length ? warnings : undefined,
-    result: dtfmTokens,
+    result: dtcgTokens,
   };
 }
 

--- a/packages/core/test/tokens-studio.test.ts
+++ b/packages/core/test/tokens-studio.test.ts
@@ -9,7 +9,7 @@ import {parse, ParseOptions} from '../src/index.js';
 function getTokens(json, parseOptions: ParseOptions = {color: {}}) {
   // the presence of top-level "$themes" and "$metadata" is necessary to detect
   // Tokens Studio format, as it always outputs these, and these are invalid
-  // for DTFM)
+  // for DTCG)
   if (!('$themes' in json)) json.$themes = [];
   if (!('$metadata' in json)) json.$metadata = {};
 

--- a/packages/core/tokens-schema.json
+++ b/packages/core/tokens-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "$id": "https://cobalt-ui.pages/dev/tokens-schema.json",
-  "title": "Design Tokens Format Module",
+  "title": "Design Tokens Community Group format",
   "additionalProperties": {
     "$ref": "#/$defs/group"
   },

--- a/packages/plugin-css/package.json
+++ b/packages/plugin-css/package.json
@@ -9,9 +9,10 @@
   "keywords": [
     "cobalt",
     "design tokens",
+    "design tokens community group",
     "design tokens format module",
     "design system",
-    "dtfm",
+    "dtcg",
     "w3c design tokens",
     "css"
   ],

--- a/packages/plugin-js/package.json
+++ b/packages/plugin-js/package.json
@@ -9,9 +9,9 @@
   "keywords": [
     "cobalt",
     "design tokens",
+    "design tokens community group",
     "design tokens format module",
     "design system",
-    "dtfm",
     "dtcg",
     "w3c design tokens"
   ],

--- a/packages/plugin-sass/README.md
+++ b/packages/plugin-sass/README.md
@@ -1,6 +1,6 @@
 # @cobalt-ui/plugin-sass
 
-Generate `.scss` and `.sass` from your Design Tokens Format Module (DTFM) tokens.
+Generate `.scss` and `.sass` from your Design Tokens Community Group (DTCG) tokens.
 
 **Features**
 

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -9,8 +9,8 @@
   "keywords": [
     "cobalt",
     "design tokens",
+    "design tokens community group",
     "design system",
-    "dtfm",
     "dtcg",
     "w3c",
     "css",

--- a/packages/plugin-tailwind/package.json
+++ b/packages/plugin-tailwind/package.json
@@ -8,9 +8,9 @@
   "keywords": [
     "cobalt",
     "design tokens",
+    "design tokens community group",
     "design tokens format module",
     "design system",
-    "dtfm",
     "dtcg",
     "w3c",
     "tailwind",


### PR DESCRIPTION
## Changes

Flip-flops on #137 and switches instead to `DTCG`.

Reasons:

1. The actual spec itself is confused, and refers to itself by different names in different places. Talking to the maintainers directly, they haven’t agreed on common terms, either.
2. After reading it over-and-over again for the past few months, my brain can’t unsee the `DTF` part of the acronym every time (don’t google that)
3. [Specify refers to it DTCG](https://specifyapp.com/blog/specify-design-token-format) (one of the few other people I see actually talking about this); why not join them?

## How to Review

Rough styleguide:

1. On any docs page, the full phrase  **Design Tokens Community Group** must introduce the acronym “DTCG” (this is not a common, nor easily-googlable acronym)
2. **Design Tokens Community Group** or **DTCG** will never appear on its own (because we never refer to the _group_ itself directly; we are usually talking about the _tokens_ or _specification_). Instead, it should always be suffixed either with `tokens`, `format`, `specification`, or something similar (e.g. `DTCG tokens`).
