### PR TITLE
Allow empty groups

### DIFF
--- a/.changeset/five-laws-stare.md
+++ b/.changeset/five-laws-stare.md
@@ -1,0 +1,5 @@
+---
+"@cobalt-ui/core": patch
+---
+
+Allows DTCG files to contain empty groups. Previously they would cause a parsing error, now only a warning will be logged.

--- a/packages/core/src/parse/index.ts
+++ b/packages/core/src/parse/index.ts
@@ -89,7 +89,7 @@ export function parse(rawTokens: unknown, options: ParseOptions): ParseResult {
         continue;
       }
       if (!Object.keys(v).length) {
-        errors.push(`${k}: groups can’t be empty`);
+        warnings.push(`${k}: group is empty`);
       }
 
       // token

--- a/packages/core/test/w3c.test.ts
+++ b/packages/core/test/w3c.test.ts
@@ -42,6 +42,15 @@ describe('5. Group', () => {
     const tokens = getTokens(json);
     expect(tokens.find((t) => t.id === 'color.blue')!.$type).toBe('color');
   });
+
+  test('allow empty', () => {
+    const json = {
+      color: {
+      },
+    };
+    const tokens = getTokens(json);
+    expect(tokens.length).toBe(0);
+  });
 });
 
 describe('7. Alias', () => {


### PR DESCRIPTION
## Changes

Makes the parser log a warning instead of an error when it encounters an empty group. Closes #206.

## How to Review

Refer to the discussion in #206 for the rationale behind this change in behaviour.

I added a regression test that fails without this fix and passes with it. However, I'm not sure if the `expect(tokens.length).toBe(0)` line is really needed, as `getTokens()` already has an `expect()` assertion to check that there were no parsing errors. It felt a bit weird having a test without an `expect()` in it though, so I added that. Happy to remove it, if you think that's cleaner / clearer.

Since this is a bug fix, I've classed it as a patch change in the changeset.