### PR TITLE
Improve APCA implementation

### DIFF
--- a/.changeset/dirty-points-sneeze.md
+++ b/.changeset/dirty-points-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@cobalt-ui/lint-a11y": patch
+---
+
+Improve APCA implementation

--- a/packages/lint-a11y/src/apca.ts
+++ b/packages/lint-a11y/src/apca.ts
@@ -193,17 +193,20 @@ export function getMinimumSilverLc(fontSize: string | number, fontWeight: number
   if (!(fontWeight > 0 && fontWeight < 1000)) {
     throw new Error(`Invalid font weight: ${fontWeight}`);
   }
+
   const sizePx = dimensionToPx(fontSize);
   const sizeRowI = APCA_FONT_LOOKUP_TABLE.findIndex(([size]) => sizePx >= size);
   if (sizeRowI === -1) {
     return 999;
   }
+
   const weightColI = Math.round(fontWeight / 100) - 1; // round weight
   const sizeDelta = sizeRowI > 0 ? (sizePx - APCA_FONT_LOOKUP_TABLE[sizeRowI]![0]) / (APCA_FONT_LOOKUP_TABLE[sizeRowI - 1]![0] - APCA_FONT_LOOKUP_TABLE[sizeRowI]![0] || 1) : 0;
   const baseLc = APCA_FONT_LOOKUP_TABLE[sizeRowI]![1][weightColI];
   if (baseLc === undefined || baseLc === 999) {
     return 999;
   }
+
   // with baseLc calculated, we may need to interpolate between font sizes; do so with simple linear interpolation
   const stepUpLc = sizeDelta > 0 ? APCA_FONT_LOOKUP_TABLE[sizeRowI - 1]![1][weightColI]! : baseLc;
   const finalLc = sizeDelta > 0 ? baseLc + sizeDelta * (stepUpLc - baseLc) : baseLc;

--- a/packages/lint-a11y/src/index.ts
+++ b/packages/lint-a11y/src/index.ts
@@ -1,20 +1,8 @@
 import { type Plugin, type ParsedToken, type LintNotice, type ParsedColorToken, type ParsedTypographyToken } from '@cobalt-ui/core';
-import { blend, modeRgb, modeHsl, modeHsv, modeP3, modeOkhsl, modeOklch, modeOklab, modeXyz50, modeXyz65, modeLrgb, useMode, wcagContrast } from 'culori/fn';
-import { APCAcontrast } from 'apca-w3';
+import { type A98, type P3, type Rgb, rgb, wcagContrast } from 'culori';
+import { APCAcontrast, adobeRGBtoY, alphaBlend, displayP3toY, sRGBtoY } from 'apca-w3';
 import { isWCAG2LargeText, round } from './lib.js';
 import { getMinimumSilverLc } from './apca.js';
-
-// register colorspaces for Culori to parse (these are side-effect-y)
-useMode(modeHsl);
-useMode(modeHsv);
-useMode(modeLrgb);
-useMode(modeOkhsl);
-useMode(modeOklab);
-useMode(modeOklch);
-useMode(modeP3);
-useMode(modeRgb);
-useMode(modeXyz50);
-const toXyz = useMode(modeXyz65);
 
 export const RULES = {
   contrast: 'a11y/contrast',
@@ -46,6 +34,28 @@ export interface RuleContrastCheck {
   wcag2?: 'AA' | 'AAA' | number | false;
   /** Enforce APCA contrast checking? (default: false) @see https://www.myndex.com/APCA/ */
   apca?: 'silver' | 'silver-nonbody' | number | false;
+}
+
+/** Note: sRGBToY uses a unique luminance. Even though this is converted to sRGB gamut, out-of-gamut colors are supported */
+function getY(primaryColor: A98 | Rgb | P3, blendColor?: A98 | Rgb | P3): number {
+  let { r, g, b } = primaryColor;
+  if (typeof primaryColor.alpha === 'number' && primaryColor.alpha < 1 && blendColor) {
+    const blended = alphaBlend([r, g, b, primaryColor.alpha], [blendColor.r, blendColor.g, blendColor.b], false);
+    r = blended[0];
+    g = blended[1];
+    b = blended[2];
+  }
+  switch (primaryColor.mode) {
+    case 'a98': {
+      return adobeRGBtoY([r, g, b]);
+    }
+    case 'p3': {
+      return displayP3toY([r, g, b]);
+    }
+    case 'rgb': {
+      return sRGBtoY([r * 255, b * 255, g * 255]);
+    }
+  }
 }
 
 function evaluateContrast(tokens: ParsedToken[], options: RuleContrastOptions): LintNotice[] {
@@ -128,23 +138,25 @@ function evaluateContrast(tokens: ParsedToken[], options: RuleContrastOptions): 
         const bgRaw = background.$extensions?.mode?.[mode] ?? background.$value;
         const typographyRaw = typography?.$extensions?.mode?.[mode] ?? typography?.$value;
 
-        // note: because modes can apply to color AND/OR typography, ignore mismatches (unlike WCAG2)
-        let { y: fgY = 0, alpha: falpha = 1 } = toXyz(fgRaw) ?? {};
-        // if foreground is slightly-transparent, calculate the displayed value
-        if (falpha < 1) {
-          const newFG = toXyz(blend([foreground.$value, background.$value], 'normal', 'lrgb'));
-          fgY = newFG.y;
-        }
-        const { y: bgY = 0 } = toXyz(bgRaw) ?? {};
-
-        testSets.push({ fgRaw, fgY, bgRaw, bgY, fontSize: typographyRaw?.fontSize, fontWeight: typographyRaw?.fontWeight, mode });
+        testSets.push({
+          fgRaw,
+          fgY: getY(rgb(fgRaw)!, rgb(bgRaw)),
+          bgRaw,
+          bgY: getY(rgb(bgRaw)!),
+          fontSize: typographyRaw?.fontSize,
+          fontWeight: typographyRaw?.fontWeight,
+          mode,
+        });
       }
 
       for (const { fgY, fgRaw, bgY, bgRaw, mode, fontSize, fontWeight } of testSets) {
         if ((apca === 'silver' || apca === 'silver-nonbody') && (!fontSize || !fontWeight)) {
           throw new Error(`APCA: "${apca}" compliance requires \`typography\` token. Use manual number if omitted.`);
         }
-        const lc = APCAcontrast(fgY, bgY);
+        const lc = APCAcontrast(
+          fgY, // First color MUST be text
+          bgY, // Second color MUST be the background.
+        );
         if (typeof lc === 'string') {
           throw new Error(`Internal error: expected number, APCA returned "${lc}"`); // types are wrong?
         }

--- a/packages/lint-a11y/test/apca.test.ts
+++ b/packages/lint-a11y/test/apca.test.ts
@@ -12,6 +12,7 @@ describe('getMinimumSilverLc', () => {
     ['19.5px/300', { given: ['19.5px', 300, false], want: 95 }],
     ['28px/200', { given: [28, 200, false], want: 100 }],
     ['96px/900', { given: ['96px', 900, false], want: 30 }],
+    ['16.5px/400', { given: ['16.5px', 400, true], want: 86.25 }],
   ];
 
   test.each(tests)('%s', (_, { given, want }) => {

--- a/packages/lint-a11y/test/fixtures/tokens.yaml
+++ b/packages/lint-a11y/test/fixtures/tokens.yaml
@@ -1,29 +1,54 @@
 color:
   $type: color
+  blue:
+    100:
+      $value: "#fafdfe"
+    200:
+      $value: "#f2fcfd"
+    300:
+      $value: "#e7f9fb"
+    400:
+      $value: "#d8f3f6"
+    500:
+      $value: "#c4eaef"
+    600:
+      $value: "#aadee6"
+    700:
+      $value: "#84cdda"
+    800:
+      $value: "#3db9cf"
+    900:
+      $value: "#05a2c2"
+    1000:
+      $value: "#0894b3"
+    1100:
+      $value: "#0c7792"
+    1200:
+      $value: "#0d3c48"
   high-contrast-text:
-    $value: '#202020'
+    $value: "#202020"
     $extensions:
       mode:
-        light: '#202020'
-        dark: '#d0d0d0'
+        light: "#202020"
+        dark: "#d0d0d0"
   high-contrast-bg:
-    $value: '#fff'
+    $value: "#fff"
     $extensions:
       mode:
-        light: '#fff'
-        dark: '#101010'
+        light: "#fff"
+        dark: "#101010"
   failing-dark-text:
-    $value: '#202020'
+    $value: "#202020"
     $extensions:
       mode:
-        light: '#202020'
-        dark: '#606060'
+        light: "#202020"
+        dark: "#606060"
   failing-dark-bg:
-    $value: '#fff'
+    $value: "#fff"
     $extensions:
       mode:
-        light: '#fff'
-        dark: '#101010'
+        light: "#fff"
+        dark: "#101010"
 typography:
   $type: typography
   large:

--- a/packages/lint-a11y/test/index.test.ts
+++ b/packages/lint-a11y/test/index.test.ts
@@ -79,7 +79,7 @@ describe('a11y plugin', () => {
             want: {
               errors: [
                 '[@cobalt-ui/lint-a11y] Error a11y/contrast: WCAG 2: Token pair #606060, #101010 (mode: dark) failed contrast. Expected 7:1 ("AAA"), received 3.03:1',
-                '[@cobalt-ui/lint-a11y] Error a11y/contrast: APCA: Token pair #606060, #101010 (mode: dark) failed contrast. Expected 75, received 22.38',
+                '[@cobalt-ui/lint-a11y] Error a11y/contrast: APCA: Token pair #606060, #101010 (mode: dark) failed contrast. Expected 75, received 20.09',
               ],
             },
           },
@@ -108,6 +108,31 @@ describe('a11y plugin', () => {
           {
             options: undefined,
             want: { errors: ['options.checks must be an array'] },
+          },
+        ],
+        [
+          'blue test',
+          {
+            options: {
+              checks: [
+                {
+                  tokens: {
+                    background: 'color.blue.1200',
+                    foreground: 'color.blue.400',
+                  },
+                  apca: 88.04,
+                },
+                {
+                  tokens: {
+                    background: 'color.blue.100',
+                    foreground: 'color.blue.900',
+                  },
+                  wcag2: 2.95,
+                  apca: 42.98,
+                },
+              ],
+            },
+            want: { success: true },
           },
         ],
       ];


### PR DESCRIPTION
## Changes

🤔 There’s something still screwy with the APCA numbers I’m getting from `apca-w3` vs the [Contrast Checker Tool](https://www.myndex.com/APCA/). There do seem to be multiple different versions of the APCA formula floating around the interwebz, npm, and Myndex’ GitHub. Hopefully I can get a review soon of this implementation (requested)!

Right now I’m chalking up a slight variance of numbers to the `apca-w3` package possibly being newer? than some of the online tools. But perhaps there’s still a bug in my code somewhere. IDK, but either way I’m seeing _better_ numbers here with the fixes.

## How to Review

- Tests updated; tests should pass
