### PR TITLE
fix(tailwind): use correct tailwind 4 import

### DIFF
--- a/.changeset/large-buses-switch.md
+++ b/.changeset/large-buses-switch.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/plugin-tailwind": patch
+---
+
+fix tailwind import

--- a/packages/plugin-tailwind/src/index.ts
+++ b/packages/plugin-tailwind/src/index.ts
@@ -50,7 +50,7 @@ export default function pluginTailwind(options: TailwindPluginOptions): Plugin {
       }
     },
     async build({ getTransforms, outputFile }) {
-      const output = ['@import "tailwind";', ''];
+      const output = ['@import "tailwindcss";', ''];
 
       const variants: Record<string, string[]> = { '.': [] };
       for (const token of getTransforms({ format: FORMAT_ID })) {

--- a/packages/plugin-tailwind/test/fixtures/primer/want.css
+++ b/packages/plugin-tailwind/test/fixtures/primer/want.css
@@ -1,4 +1,4 @@
-@import "tailwind";
+@import "tailwindcss";
 
 @theme {
   --color-blue-0: #ddf4ff;


### PR DESCRIPTION
## Changes

The output from the tailwind plugin uses the incorrect import. This causes an error at runtime.

See https://tailwindcss.com/docs/installation/using-vite and https://tailwindcss.com/docs/upgrade-guide#removed-tailwind-directives for examples of correct usage.

## How to Review

Generate a tailwind config output and try using it

Thanks!
