### PR TITLE
feat(plugin-css): Add support for `color-scheme` property

### DIFF
--- a/.changeset/grumpy-oranges-walk.md
+++ b/.changeset/grumpy-oranges-walk.md
@@ -1,0 +1,8 @@
+---
+"@terrazzo/plugin-css": patch
+"@terrazzo/plugin-sass": patch
+"@terrazzo/plugin-tailwind": patch
+"@terrazzo/plugin-vanilla-extract": patch
+---
+
+Add support for color-scheme property

--- a/packages/plugin-css/src/build/index.ts
+++ b/packages/plugin-css/src/build/index.ts
@@ -13,6 +13,7 @@ export interface BuildFormatOptions {
   modeSelectors: CSSPluginOptions['modeSelectors'];
   utility: CSSPluginOptions['utility'];
   baseSelector: string;
+  baseScheme: CSSPluginOptions['baseScheme'];
 }
 
 export default function buildFormat({
@@ -21,6 +22,7 @@ export default function buildFormat({
   utility,
   modeSelectors,
   baseSelector,
+  baseScheme,
 }: BuildFormatOptions): string {
   const rules: CSSRule[] = [];
 
@@ -40,6 +42,11 @@ export default function buildFormat({
     rules.push(rootRule, p3Rule, rec2020Rule);
 
     const shouldExclude = wcmatch(exclude ?? []);
+
+    // add base color-scheme declaration if configured
+    if (baseScheme) {
+      rootRule.declarations['color-scheme'] = { value: baseScheme };
+    }
 
     for (const token of rootTokens) {
       // handle exclude (if any)
@@ -98,8 +105,8 @@ export default function buildFormat({
     }
   }
 
-  // modeSelectors (note: without these, modes won’t get written to CSS)
-  for (const { selectors, tokens, mode } of modeSelectors ?? []) {
+  // modeSelectors (note: without these, modes won't get written to CSS)
+  for (const { selectors, tokens, mode, scheme } of modeSelectors ?? []) {
     if (!selectors.length) {
       continue;
     }
@@ -113,6 +120,11 @@ export default function buildFormat({
     const selectorRec2020Rule: CSSRule = { selectors, nestedQuery: REC2020_MQ, declarations: {} };
     const selectorAliasDeclarations: CSSRule['declarations'] = {};
     rules.push(selectorRule, selectorP3Rule, selectorRec2020Rule);
+
+    // add color-scheme declaration if configured for this mode
+    if (scheme) {
+      selectorRule.declarations['color-scheme'] = { value: scheme };
+    }
 
     for (const token of selectorTokens) {
       const localID = token.localID ?? token.token.id;

--- a/packages/plugin-css/src/index.ts
+++ b/packages/plugin-css/src/index.ts
@@ -16,6 +16,7 @@ export default function cssPlugin(options?: CSSPluginOptions): Plugin {
     utility,
     legacyHex,
     skipBuild,
+    baseScheme,
   } = options ?? {};
 
   const filename = options?.filename ?? (options as any)?.fileName ?? 'index.css';
@@ -73,7 +74,7 @@ export default function cssPlugin(options?: CSSPluginOptions): Plugin {
 
       const output: string[] = [FILE_PREFIX, ''];
       output.push(
-        buildFormat({ exclude, getTransforms, modeSelectors, utility, baseSelector }),
+        buildFormat({ exclude, getTransforms, modeSelectors, utility, baseSelector, baseScheme }),
         '\n', // EOF newline
       );
       outputFile(filename, output.join('\n'));

--- a/packages/plugin-css/src/lib.ts
+++ b/packages/plugin-css/src/lib.ts
@@ -41,6 +41,10 @@ export interface CSSPluginOptions {
    * @default ":root"
    */
   baseSelector?: string;
+  /**
+   * Set the color-scheme CSS property for the base selector (e.g.: "light", "dark", "light dark")
+   */
+  baseScheme?: string;
 }
 
 export interface ModeSelector {
@@ -50,6 +54,8 @@ export interface ModeSelector {
   tokens?: string[];
   /** Provide CSS selectors to generate. (e.g.: `["@media (prefers-color-scheme: dark)", "[data-color-theme='dark']"]` ) */
   selectors: string[];
+  /** Set the color-scheme CSS property for this mode (e.g.: "light", "dark", "light dark") */
+  scheme?: string;
 }
 
 // A CSSRule is a sort of “we have AST at home” shortcut that provides the benefit of normalized formatting

--- a/packages/plugin-css/test/js.test.ts
+++ b/packages/plugin-css/test/js.test.ts
@@ -271,5 +271,43 @@ describe('Node.js API', () => {
         fileURLToPath(new URL('./want.css', cwd)),
       );
     });
+
+    it('color-scheme properties', async () => {
+      const output = 'actual.css';
+      const cwd = new URL('./fixtures/color-scheme/', import.meta.url);
+      const config = defineConfig(
+        {
+          plugins: [
+            css({
+              filename: output,
+              baseScheme: 'light dark',
+              modeSelectors: [
+                {
+                  mode: 'light',
+                  tokens: ['color.*'],
+                  selectors: ['@media (prefers-color-scheme: light)', '[data-color-theme="light"]'],
+                  scheme: 'light',
+                },
+                {
+                  mode: 'dark',
+                  tokens: ['color.*'],
+                  selectors: ['@media (prefers-color-scheme: dark)', '[data-color-theme="dark"]'],
+                  scheme: 'dark',
+                },
+              ],
+            }),
+          ],
+        },
+        { cwd },
+      );
+      const tokensJSON = new URL('./tokens.json', cwd);
+      const { tokens, sources } = await parse([{ filename: tokensJSON, src: fs.readFileSync(tokensJSON, 'utf8') }], {
+        config,
+      });
+      const result = await build(tokens, { sources, config });
+      await expect(result.outputFiles.find((f) => f.filename === output)?.contents).toMatchFileSnapshot(
+        fileURLToPath(new URL('./want.css', cwd)),
+      );
+    });
   });
 });

--- a/packages/plugin-css/test/lib.test.ts
+++ b/packages/plugin-css/test/lib.test.ts
@@ -157,4 +157,68 @@ describe('printRules', () => {
       }"
     `);
   });
+
+  it('color-scheme declarations', () => {
+    const rules: CSSRule[] = [
+      {
+        selectors: [':root'],
+        declarations: {
+          'color-scheme': { value: 'light dark' },
+          '--color-blue-6': { value: '#acd8fc' },
+          '--color-blue-7': { value: '#8ec8f6' },
+        },
+      },
+      {
+        selectors: ['@media (prefers-color-scheme: light)', '[data-color-theme="light"]'],
+        declarations: {
+          'color-scheme': { value: 'light' },
+          '--color-blue-6': { value: '#acd8fc' },
+          '--color-blue-7': { value: '#8ec8f6' },
+        },
+      },
+      {
+        selectors: ['@media (prefers-color-scheme: dark)', '[data-color-theme="dark"]'],
+        declarations: {
+          'color-scheme': { value: 'dark' },
+          '--color-blue-6': { value: '#104d87' },
+          '--color-blue-7': { value: '#205d9e' },
+        },
+      },
+    ];
+    expect(printRules(rules)).toMatchInlineSnapshot(`
+      ":root {
+        color-scheme: light dark;
+        --color-blue-6: #acd8fc;
+        --color-blue-7: #8ec8f6;
+      }
+
+      @media (prefers-color-scheme: light) {
+        :root {
+          color-scheme: light;
+          --color-blue-6: #acd8fc;
+          --color-blue-7: #8ec8f6;
+        }
+      }
+
+      [data-color-theme="light"] {
+        color-scheme: light;
+        --color-blue-6: #acd8fc;
+        --color-blue-7: #8ec8f6;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          color-scheme: dark;
+          --color-blue-6: #104d87;
+          --color-blue-7: #205d9e;
+        }
+      }
+
+      [data-color-theme="dark"] {
+        color-scheme: dark;
+        --color-blue-6: #104d87;
+        --color-blue-7: #205d9e;
+      }"
+    `);
+  });
 });


### PR DESCRIPTION
## Changes

Provide support for the `color-scheme` CSS property by respectivley adding both `baseScheme` and `scheme` to `CSSPluginOptions` and `ModeSelector`. 

Closes #549

## How to Review

These new options shouldn't bring any breaking change as they are optional.
