### PR TITLE
ci: remove www from changelog

### DIFF
--- a/.changeset/full-webs-shake.md
+++ b/.changeset/full-webs-shake.md
@@ -6,7 +6,6 @@
 "@terrazzo/plugin-css": patch
 "@terrazzo/plugin-js": patch
 "@terrazzo/parser": patch
-"@terrazzo/www": patch
 ---
 
 Add support for the Token Listing format


### PR DESCRIPTION
## Changes

Changesets throws an error for the docs, since we don’t keep a changeset or publish that to npm

## How to Review

N/A
