### PR TITLE
Update legacy Terrazzo modes to a synthetic Resolver

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,7 +60,7 @@
     "meriyah": "^6.1.4",
     "mime": "^4.1.0",
     "picocolors": "^1.1.1",
-    "vite": "^7.2.2",
+    "vite": "catalog:",
     "vite-node": "^5.2.0",
     "yaml-to-momoa": "catalog:"
   },

--- a/packages/parser/src/parse/index.ts
+++ b/packages/parser/src/parse/index.ts
@@ -2,6 +2,7 @@ import type fsType from 'node:fs/promises';
 import { pluralize, type TokenNormalizedSet } from '@terrazzo/token-tools';
 import lintRunner from '../lint/index.js';
 import Logger from '../logger.js';
+import { createSyntheticResolver } from '../resolver/create-synthetic-resolver.js';
 import { loadResolver } from '../resolver/load.js';
 import type { ConfigInit, InputSource, ParseOptions, Resolver } from '../types.js';
 import { loadSources } from './load.js';
@@ -9,7 +10,7 @@ import { loadSources } from './load.js';
 export interface ParseResult {
   tokens: TokenNormalizedSet;
   sources: InputSource[];
-  resolver?: Resolver | undefined;
+  resolver: Resolver;
 }
 
 /** Parse */
@@ -80,7 +81,7 @@ export default async function parse(
   return {
     tokens,
     sources,
-    resolver,
+    resolver: resolver || (await createSyntheticResolver(tokens, { logger, req })),
   };
 }
 

--- a/packages/parser/src/resolver/create-synthetic-resolver.ts
+++ b/packages/parser/src/resolver/create-synthetic-resolver.ts
@@ -1,0 +1,78 @@
+import * as momoa from '@humanwhocodes/momoa';
+import type Logger from '../logger.js';
+import type { Group, Resolver, TokenNormalized, TokenNormalizedSet } from '../types.js';
+import { createResolver } from './load.js';
+import { normalizeResolver } from './normalize.js';
+
+/**
+ * Interop layer upgrading legacy Terrazzo modes to resolvers
+ */
+export async function createSyntheticResolver(
+  tokens: TokenNormalizedSet,
+  { logger, req }: { logger: Logger; req: (url: URL, origin: URL) => Promise<string> },
+): Promise<Resolver> {
+  const contexts: Record<string, any[]> = {};
+  for (const token of Object.values(tokens)) {
+    for (const [mode, value] of Object.entries(token.mode)) {
+      if (mode === '.') {
+        continue;
+      }
+      if (!(mode in contexts)) {
+        contexts[mode] = [{}];
+      }
+      addToken(contexts[mode]![0], { ...token, $value: value.$value }, { logger });
+    }
+  }
+
+  const src = JSON.stringify(
+    {
+      name: 'Terrazzo',
+      version: '2025.10',
+      resolutionOrder: [{ $ref: '#/sets/allTokens' }, { $ref: '#/modifiers/tzMode' }],
+      sets: {
+        allTokens: { sources: [simpleFlatten(tokens, { logger })] },
+      },
+      modifiers: {
+        tzMode: {
+          description: 'Automatically built from $extensions.mode',
+          contexts,
+        },
+      },
+    },
+    undefined,
+    2,
+  );
+  const normalized = await normalizeResolver(momoa.parse(src), {
+    filename: new URL('file:///virtual:resolver.json'),
+    logger,
+    req,
+    src,
+  });
+  return createResolver(normalized, { logger });
+}
+
+/** Add a normalized token back into an arbitrary, hierarchial structure */
+function addToken(structure: any, token: TokenNormalized, { logger }: { logger: Logger }): void {
+  let node = structure;
+  const parts = token.id.split('.');
+  const localID = parts.pop()!;
+  for (const part of parts) {
+    if (!(part in node)) {
+      node[part] = {};
+    }
+    node = node[part];
+  }
+  if (localID in node) {
+    logger.error({ group: 'parser', label: 'resolver', message: `${localID} already exists!` });
+  }
+  node[localID] = { $type: token.$type, $value: token.$value };
+}
+
+/** Downconvert normalized tokens back into a simplified, hierarchial shape. This is extremely lossy, and only done to build a resolver. */
+function simpleFlatten(tokens: TokenNormalizedSet, { logger }: { logger: Logger }): Group {
+  const group: Group = {};
+  for (const token of Object.values(tokens)) {
+    addToken(group, token, { logger });
+  }
+  return group;
+}

--- a/packages/parser/src/resolver/load.ts
+++ b/packages/parser/src/resolver/load.ts
@@ -1,4 +1,4 @@
-import type { DocumentNode } from '@humanwhocodes/momoa';
+import * as momoa from '@humanwhocodes/momoa';
 import { maybeRawJSON } from '@terrazzo/json-schema-tools';
 import type { TokenNormalizedSet } from '@terrazzo/token-tools';
 import eq from 'fast-deep-equal';
@@ -21,14 +21,14 @@ export async function loadResolver(
   inputs: Omit<InputSource, 'document'>[],
   { logger, req, yamlToMomoa }: LoadResolverOptions,
 ): Promise<Resolver | undefined> {
-  let resolverDoc: DocumentNode | undefined;
+  let resolverDoc: momoa.DocumentNode | undefined;
   const entry = {
     group: 'parser',
     label: 'init',
   } as const;
 
   for (const input of inputs) {
-    let document: DocumentNode | undefined;
+    let document: momoa.DocumentNode | undefined;
     if (typeof input.src === 'string') {
       if (maybeRawJSON(input.src)) {
         document = toMomoa(input.src);

--- a/packages/parser/src/resolver/validate.ts
+++ b/packages/parser/src/resolver/validate.ts
@@ -1,4 +1,4 @@
-import type { DocumentNode, ObjectNode } from '@humanwhocodes/momoa';
+import type * as momoa from '@humanwhocodes/momoa';
 import { getObjMember, getObjMembers } from '@terrazzo/json-schema-tools';
 import type { LogEntry, default as Logger } from '../logger.js';
 
@@ -10,7 +10,7 @@ import type { LogEntry, default as Logger } from '../logger.js';
  * guesswork here, but we try and find a reasonable edge case where we sniff out
  * invalid DTCG syntax that a resolver doc would have.
  */
-export function isLikelyResolver(doc: DocumentNode): boolean {
+export function isLikelyResolver(doc: momoa.DocumentNode): boolean {
   if (doc.body.type !== 'Object') {
     return false;
   }
@@ -79,7 +79,7 @@ const MESSAGE_EXPECTED = {
  * Validate a resolver document.
  * There’s a ton of boilerplate here, only to surface detailed code frames. Is there a better abstraction?
  */
-export function validateResolver(node: DocumentNode, { logger, src }: ValidateResolverOptions) {
+export function validateResolver(node: momoa.DocumentNode, { logger, src }: ValidateResolverOptions) {
   const entry = { group: 'parser', label: 'resolver', src } as const;
   if (node.body.type !== 'Object') {
     logger.error({ ...entry, message: MESSAGE_EXPECTED.OBJECT, node });
@@ -89,7 +89,7 @@ export function validateResolver(node: DocumentNode, { logger, src }: ValidateRe
   let hasVersion = false;
   let hasResolutionOrder = false;
 
-  for (const member of (node.body as ObjectNode).members) {
+  for (const member of (node.body as momoa.ObjectNode).members) {
     if (member.name.type !== 'String') {
       continue; // IDK, don’t ask
     }
@@ -202,7 +202,7 @@ export function validateResolver(node: DocumentNode, { logger, src }: ValidateRe
   }
 }
 
-export function validateSet(node: ObjectNode, isInline = false, { src }: ValidateResolverOptions): LogEntry[] {
+export function validateSet(node: momoa.ObjectNode, isInline = false, { src }: ValidateResolverOptions): LogEntry[] {
   const entry = { group: 'parser', label: 'resolver', src } as const;
   const errors: LogEntry[] = [];
   let hasName = !isInline;
@@ -277,7 +277,11 @@ export function validateSet(node: ObjectNode, isInline = false, { src }: Validat
   return errors;
 }
 
-export function validateModifier(node: ObjectNode, isInline = false, { src }: ValidateResolverOptions): LogEntry[] {
+export function validateModifier(
+  node: momoa.ObjectNode,
+  isInline = false,
+  { src }: ValidateResolverOptions,
+): LogEntry[] {
   const errors: LogEntry[] = [];
   const entry = { group: 'parser', label: 'resolver', src } as const;
   let hasName = !isInline;

--- a/packages/plugin-js/README.md
+++ b/packages/plugin-js/README.md
@@ -20,8 +20,7 @@ export default defineConfig({
   outDir: "./tokens/",
   plugins: [
     js({
-      js: "index.js",
-      // json: "tokens.json",
+      filename: "tokens.js", // Note: `.d.ts` is generated too, so this is TypeScript-compatible!
     }),
   ],
 });
@@ -33,6 +32,6 @@ Lastly, run:
 npx tz build
 ```
 
-And you’ll see a `./tokens/index.js` file generated in your project.
+And you’ll see a `./tokens/tokens.js` file generated in your project.
 
 [Full Documentation](https://terrazzo.app/docs/integrations/js)

--- a/packages/token-lab/src/hooks/tokens.ts
+++ b/packages/token-lab/src/hooks/tokens.ts
@@ -28,7 +28,20 @@ const TZ_CONFIG = defineConfig(
 // - the terrazzo parser works with strings better (for column/row errors)
 const $tokens = atom('{}');
 const $tokensLoaded = atom(false); // singleton to prevent multiple loads from IndexedDB
-const $parseResult = atom<ParseResult>({ tokens: {}, sources: [] });
+const $parseResult = atom<ParseResult>({
+  tokens: {},
+  sources: [],
+  resolver: {
+    apply() {
+      return {};
+    },
+    source: {} as any,
+    permutations: [],
+    isValidInput() {
+      return false;
+    },
+  },
+});
 const $parseError = atom<TokensJSONError | undefined>();
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ catalogs:
       specifier: ^4.0.10
       version: 4.0.10
     yaml-to-momoa:
-      specifier: 0.0.6
-      version: 0.0.6
+      specifier: 0.0.8
+      version: 0.0.8
 
 patchedDependencies:
   vite-plugin-sass-dts:
@@ -242,14 +242,14 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       vite:
-        specifier: ^7.2.2
+        specifier: 'catalog:'
         version: 7.2.2(@types/node@24.10.1)(jiti@2.6.1)(sass-embedded@1.85.1)(yaml@2.8.1)
       vite-node:
         specifier: ^5.2.0
         version: 5.2.0(@types/node@24.10.1)(jiti@2.6.1)(sass-embedded@1.85.1)(yaml@2.8.1)
       yaml-to-momoa:
         specifier: 'catalog:'
-        version: 0.0.6
+        version: 0.0.8
     devDependencies:
       '@swc/core':
         specifier: 'catalog:'
@@ -331,7 +331,7 @@ importers:
         version: 11.9.3
       yaml-to-momoa:
         specifier: 'catalog:'
-        version: 0.0.6
+        version: 0.0.8
 
   packages/parser:
     dependencies:
@@ -371,7 +371,7 @@ importers:
     devDependencies:
       yaml-to-momoa:
         specifier: 'catalog:'
-        version: 0.0.6
+        version: 0.0.8
 
   packages/plugin-css:
     dependencies:
@@ -3613,8 +3613,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  electron-to-chromium@1.5.257:
-    resolution: {integrity: sha512-VNSOB6JZan5IQNMqaurYpZC4bDPXcvKlUwVD/ztMeVD7SwOpMYGOY7dgt+4lNiIHIpvv/FdULnZKqKEy2KcuHQ==}
+  electron-to-chromium@1.5.258:
+    resolution: {integrity: sha512-rHUggNV5jKQ0sSdWwlaRDkFc3/rRJIVnOSe9yR4zrR07m3ZxhP4N27Hlg8VeJGGYgFTxK5NqDmWI4DSH72vIJg==}
 
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
@@ -6255,8 +6255,8 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yaml-to-momoa@0.0.6:
-    resolution: {integrity: sha512-H6OxymcTIB5fTCQV7/+ETO9Wh6v1vpBDpmW94XnscKE+jQl6x58us/G6r6z5IiPCi5wuSvJ+0wipUsp0s2/Yyg==}
+  yaml-to-momoa@0.0.8:
+    resolution: {integrity: sha512-ukog7yNG9jM/2lwG9RFnAYabuVl9wCqudfnXKsk1jkVIImPfS6JizmXNHqq7ansuJtWQN95sAP8m1PfoCOuLsQ==}
 
   yaml@2.8.1:
     resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
@@ -8224,7 +8224,7 @@ snapshots:
 
   '@types/fontkit@2.0.8':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 24.10.1
 
   '@types/google.maps@3.58.1': {}
 
@@ -8832,7 +8832,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.8.29
       caniuse-lite: 1.0.30001756
-      electron-to-chromium: 1.5.257
+      electron-to-chromium: 1.5.258
       node-releases: 2.0.27
       update-browserslist-db: 1.1.4(browserslist@4.28.0)
 
@@ -9234,7 +9234,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  electron-to-chromium@1.5.257: {}
+  electron-to-chromium@1.5.258: {}
 
   emoji-regex-xs@1.0.0: {}
 
@@ -12339,7 +12339,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml-to-momoa@0.0.6:
+  yaml-to-momoa@0.0.8:
     dependencies:
       '@humanwhocodes/momoa': 3.3.10
       yaml: 2.8.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,7 +30,7 @@ catalog:
   react-dom: ^19.2.0
   vite: ^7.2.2
   vitest: ^4.0.10
-  yaml-to-momoa: 0.0.6
+  yaml-to-momoa: 0.0.8
 
 onlyBuiltDependencies:
   - '@biomejs/biome'

--- a/www/src/pages/docs/2.0/integrations/css.md
+++ b/www/src/pages/docs/2.0/integrations/css.md
@@ -25,11 +25,11 @@ And add it to `terrazzo.config.ts` under `plugins`:
 
 ```ts [terrazzo.config.ts]
 import { defineConfig } from "@terrazzo/cli";
-import pluginCSS from "@terrazzo/plugin-css";
+import css from "@terrazzo/plugin-css";
 
 export default defineConfig({
   plugins: [
-    pluginCSS({
+    css({
       filename: "tokens.css",
       variableName: (id) => id.replace(/\./g, "-"),
       baseSelector: ":root",

--- a/www/src/pages/docs/2.0/reference/tokens.md
+++ b/www/src/pages/docs/2.0/reference/tokens.md
@@ -53,7 +53,7 @@ Color is a frequently-used base token that can be aliased within the following c
 
 ### Tips & recommendations
 
-- [Culori](https://culorijs.org/) is the preferred library for working with color. It’s great both as an accurate, complete color science library that can parse & generate any format. But is also easy-to-use for simple color operations and is fast and [lightweight](https://culorijs.org/guides/tree-shaking/) (even on the client).
+- [Color.js](https://colorjs.io/docs/procedural) is the preferred library for working with color. It’s great both as an accurate, complete color science library that can parse & generate any format. But is also easy-to-use for simple color operations and is fast and [lightweight](https://colorjs.io/docs/procedural) (even on the client).
 - Prefer the [OKLCH](https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl) format for declaring colors ([why?](https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl)). It’s not only a [futureproof standard](https://www.w3.org/TR/css-color-4/#ok-lab); it also allows for better color manipulation than sRGB/hex and is more perceptually-even.
 
 ## Dimension
@@ -520,7 +520,7 @@ A composite type combining [color](#color) and [number](#number)(normalized to `
 
 ### Tips & recommendations
 
-- [Culori](https://culorijs.org/) is the preferred library for working with color. It’s great both as an accurate, complete color science library that can parse & generate any format. But is also easy-to-use for simple color operations and is fast and [lightweight](https://culorijs.org/guides/tree-shaking/) (even on the client).
+- [Color.js](https://colorjs.io/docs/procedural) is the preferred library for working with color. It’s great both as an accurate, complete color science library that can parse & generate any format. But is also easy-to-use for simple color operations and is fast and [lightweight](https://colorjs.io/docs/procedural) (even on the client)
 - Prefer the [OKLCH](https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl) format for declaring colors ([why?](https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl)). It’s not only a [futureproof standard](https://www.w3.org/TR/css-color-4/#ok-lab); it also allows for better color manipulation than sRGB/hex and is more perceptually-even.
 
 ## Typography

--- a/www/src/pages/docs/integrations/css.md
+++ b/www/src/pages/docs/integrations/css.md
@@ -25,11 +25,11 @@ And add it to `terrazzo.config.js` under `plugins`:
 
 ```js [terrazzo.config.js]
 import { defineConfig } from "@terrazzo/cli";
-import pluginCSS from "@terrazzo/plugin-css";
+import css from "@terrazzo/plugin-css";
 
 export default defineConfig({
   plugins: [
-    pluginCSS({
+    css({
       filename: "tokens.css",
       variableName: (id) => id.replace(/\./g, "-"),
       baseSelector: ":root",

--- a/www/src/pages/docs/integrations/js.md
+++ b/www/src/pages/docs/integrations/js.md
@@ -27,11 +27,11 @@ npm i -D @terrazzo/plugin-js
 
 ```js [terrazzo.config.js]
 import { defineConfig } from "@terrazzo/cli";
-import pluginJS from "@terrazzo/plugin-js";
+import js from "@terrazzo/plugin-js";
 
 export default defineConfig({
   plugins: [
-    pluginJS({
+    js({
       js: "index.js",
       ts: "index.d.ts",
       json: false, // set to a filename to generate JSON
@@ -58,11 +58,11 @@ Configure options in [terrazzo.config.js](/docs/reference/config):
 
 ```js [terrazzo.config.js]
 import { defineConfig } from "@terrazzo/cli";
-import pluginJS from "@terrazzo/plugin-js";
+import js from "@terrazzo/plugin-js";
 
 export default defineConfig({
   plugins: [
-    pluginJS({
+    js({
       /* options */
     }),
   ],

--- a/www/src/pages/docs/reference/tokens.md
+++ b/www/src/pages/docs/reference/tokens.md
@@ -53,7 +53,7 @@ Color is a frequently-used base token that can be aliased within the following c
 
 ### Tips & recommendations
 
-- [Culori](https://culorijs.org/) is the preferred library for working with color. It’s great both as an accurate, complete color science library that can parse & generate any format. But is also easy-to-use for simple color operations and is fast and [lightweight](https://culorijs.org/guides/tree-shaking/) (even on the client).
+- [Color.js](https://colorjs.io/docs/procedural) is the preferred library for working with color. It’s great both as an accurate, complete color science library that can parse & generate any format. But is also easy-to-use for simple color operations and is fast and [lightweight](https://colorjs.io/docs/procedural) (even on the client)
 - Prefer the [OKLCH](https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl) format for declaring colors ([why?](https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl)). It’s not only a [futureproof standard](https://www.w3.org/TR/css-color-4/#ok-lab); it also allows for better color manipulation than sRGB/hex and is more perceptually-even.
 
 ## Dimension
@@ -520,7 +520,7 @@ A composite type combining [color](#color) and [number](#number)(normalized to `
 
 ### Tips & recommendations
 
-- [Culori](https://culorijs.org/) is the preferred library for working with color. It’s great both as an accurate, complete color science library that can parse & generate any format. But is also easy-to-use for simple color operations and is fast and [lightweight](https://culorijs.org/guides/tree-shaking/) (even on the client).
+- [Color.js](https://colorjs.io/docs/procedural) is the preferred library for working with color. It’s great both as an accurate, complete color science library that can parse & generate any format. But is also easy-to-use for simple color operations and is fast and [lightweight](https://colorjs.io/docs/procedural) (even on the client)
 - Prefer the [OKLCH](https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl) format for declaring colors ([why?](https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl)). It’s not only a [futureproof standard](https://www.w3.org/TR/css-color-4/#ok-lab); it also allows for better color manipulation than sRGB/hex and is more perceptually-even.
 
 ## Typography


### PR DESCRIPTION
## Changes

This lets folks use legacy Terrazzo modes with the new resolver syntax, without requiring any changes to the source tokens. This now always returns a `resolver` from `parse()`, which means both the old and new syntax will be supported (at least for all of 2.0).

There’s still some followup PRs and tests needed to fully support Resolvers, but the end is close! 🤞 

## How to Review

- Tests added; tests should pass.
