### PR TITLE
Example for #593

### DIFF
--- a/packages/plugin-css/rolldown.config.ts
+++ b/packages/plugin-css/rolldown.config.ts
@@ -1,12 +1,15 @@
 import { defineConfig } from 'rolldown';
 import { dts } from 'rolldown-plugin-dts';
 
+import pkg from './package.json';
+
 export default defineConfig({
   input: {
     index: './src/index.ts',
   },
   platform: 'browser',
-  plugins: [dts()],
+  plugins: [dts({resolve: true})],
+  external: Object.keys(pkg.dependencies).flatMap(k => [k, new RegExp(`^${k}\/.*`)]),
   output: {
     dir: 'dist',
     format: 'es',


### PR DESCRIPTION
- re: #593

update config for `@terrazzo/plugin-css` to generate 'correct' output (no unnecessarily bundled js, no missing bundled types).


i'm surprised/disappointed arethetypeswrong didn't pick up on the transitive types

before:

```
<DIR>/index.d.ts      chunk │ size:   3.28 kB
<DIR>/index.js        chunk │ size: 145.43 kB
```

after:
```
<DIR>/index.d.ts      chunk │ size: 16.04 kB
<DIR>/index.js        chunk │ size: 16.35 kB
```

after, but also promoting `@terrazzo/parser` from dev to prod dep:

```
<DIR>/index.d.ts      chunk │ size:  3.28 kB
<DIR>/index.js        chunk │ size: 16.35 kB
```