### PR TITLE
docs: Fix localhost links to use relative paths

### DIFF
--- a/www/src/pages/docs/2.0/integrations/css.md
+++ b/www/src/pages/docs/2.0/integrations/css.md
@@ -598,7 +598,7 @@ Its usage has changed slightly from Cobalt 1.x, because now it must return eithe
 
 :::warning
 
-Some token types that require multiple values (like [typography](http://localhost:4321/docs/reference/tokens#typography)) must return an object.
+Some token types that require multiple values (like [typography](/docs/reference/tokens#typography)) must return an object.
 
 :::
 

--- a/www/src/pages/docs/integrations/css.md
+++ b/www/src/pages/docs/integrations/css.md
@@ -596,7 +596,7 @@ Its usage has changed slightly from Cobalt 1.x, because now it must return eithe
 
 :::warning
 
-Some token types that require multiple values (like [typography](http://localhost:4321/docs/reference/tokens#typography)) must return an object.
+Some token types that require multiple values (like [typography](/docs/reference/tokens#typography)) must return an object.
 
 :::
 


### PR DESCRIPTION
This PR fixes hardcoded localhost:4321 URLs in typography token documentation.