### PR TITLE
Fix Tailwind config theme key from 'colors' to 'color'

### DIFF
--- a/www/src/pages/docs/integrations/tailwind.md
+++ b/www/src/pages/docs/integrations/tailwind.md
@@ -37,7 +37,7 @@ export default defineConfig({
 
       theme: {
         /** @see https://tailwindcss.com/docs/configuration#theme */
-        colors: ["color.*"],
+        color: ["color.*"],
         font: {
           sans: "typography.family.base",
         },


### PR DESCRIPTION
This PR corrects the Tailwind configuration theme key from `colors` to `color` in the documentation.