### PR TITLE
fix: Allow partial utility CSS groups configuration

### DIFF
--- a/.changeset/partial-utility-groups.md
+++ b/.changeset/partial-utility-groups.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/plugin-css": patch
+---
+
+Allow partial utility CSS groups configuration

--- a/packages/plugin-css/src/build/utility-css.ts
+++ b/packages/plugin-css/src/build/utility-css.ts
@@ -26,7 +26,7 @@ function makeVarValue(token: TokenTransformed): CSSRuleDeclaration {
 }
 
 export default function generateUtilityCSS(
-  groups: Record<UtilityCSSGroup, string[]>,
+  groups: Partial<Record<UtilityCSSGroup, string[]>>,
   tokens: TokenTransformed[],
 ): CSSRule[] {
   const output: CSSRule[] = [];

--- a/packages/plugin-css/src/lib.ts
+++ b/packages/plugin-css/src/lib.ts
@@ -25,7 +25,7 @@ export interface CSSPluginOptions {
   /** Override certain token values */
   transform?: (token: TokenNormalized, mode: string) => TokenTransformed['value'];
   /** Generate utility CSS from groups */
-  utility?: Record<UtilityCSSGroup, string[]>;
+  utility?: Partial<Record<UtilityCSSGroup, string[]>>;
   /**
    * Output colors as hex-6/hex-8 instead of color() function
    * @default false


### PR DESCRIPTION
This PR allows users to provide only the utility CSS groups they need instead of requiring all groups.