### PR TITLE
Use en-us locale for all Intl formats

### DIFF
--- a/packages/parser/src/lint/plugin-core/rules/valid-border.ts
+++ b/packages/parser/src/lint/plugin-core/rules/valid-border.ts
@@ -12,7 +12,7 @@ const ERROR_INVALID_PROP = 'ERROR_INVALID_PROP';
 const rule: LintRule<typeof ERROR | typeof ERROR_INVALID_PROP, {}> = {
   meta: {
     messages: {
-      [ERROR]: `Border token missing required properties: ${new Intl.ListFormat(undefined, { type: 'conjunction' }).format(BORDER_REQUIRED_PROPERTIES)}.`,
+      [ERROR]: `Border token missing required properties: ${new Intl.ListFormat('en-us', { type: 'conjunction' }).format(BORDER_REQUIRED_PROPERTIES)}.`,
       [ERROR_INVALID_PROP]: 'Unknown property: {{ key }}.',
     },
     docs: {

--- a/packages/parser/src/lint/plugin-core/rules/valid-color.ts
+++ b/packages/parser/src/lint/plugin-core/rules/valid-color.ts
@@ -54,7 +54,7 @@ const rule: LintRule<
   meta: {
     messages: {
       [ERROR_ALPHA]: `Alpha {{ alpha }} not in range 0 – 1.`,
-      [ERROR_INVALID_COLOR_SPACE]: `Invalid color space: {{ colorSpace }}. Expected ${new Intl.ListFormat(undefined, { type: 'disjunction' }).format(Object.keys(COLORSPACE))}`,
+      [ERROR_INVALID_COLOR_SPACE]: `Invalid color space: {{ colorSpace }}. Expected ${new Intl.ListFormat('en-us', { type: 'disjunction' }).format(Object.keys(COLORSPACE))}`,
       [ERROR_INVALID_COLOR]: `Could not parse color {{ color }}.`,
       [ERROR_INVALID_COMPONENT_LENGTH]: 'Expected {{ expected }} components, received {{ got }}.',
       [ERROR_INVALID_HEX8]: `Hex value can’t be semi-transparent.`,

--- a/packages/parser/src/lint/plugin-core/rules/valid-font-weight.ts
+++ b/packages/parser/src/lint/plugin-core/rules/valid-font-weight.ts
@@ -21,7 +21,7 @@ export interface RuleFontWeightOptions {
 const rule: LintRule<typeof ERROR | typeof ERROR_STYLE, RuleFontWeightOptions> = {
   meta: {
     messages: {
-      [ERROR]: `Must either be a valid number (0 - 999) or a valid font weight: ${new Intl.ListFormat(undefined, { type: 'disjunction' }).format(Object.keys(FONT_WEIGHTS))}.`,
+      [ERROR]: `Must either be a valid number (0 - 999) or a valid font weight: ${new Intl.ListFormat('en-us', { type: 'disjunction' }).format(Object.keys(FONT_WEIGHTS))}.`,
       [ERROR_STYLE]: 'Expected style {{ style }}, received {{ value }}.',
     },
     docs: {

--- a/packages/parser/src/lint/plugin-core/rules/valid-shadow.ts
+++ b/packages/parser/src/lint/plugin-core/rules/valid-shadow.ts
@@ -12,7 +12,7 @@ const ERROR_INVALID_PROP = 'ERROR_INVALID_PROP';
 const rule: LintRule<typeof ERROR | typeof ERROR_INVALID_PROP> = {
   meta: {
     messages: {
-      [ERROR]: `Missing required properties: ${new Intl.ListFormat(undefined, { type: 'conjunction' }).format(SHADOW_REQUIRED_PROPERTIES)}.`,
+      [ERROR]: `Missing required properties: ${new Intl.ListFormat('en-us', { type: 'conjunction' }).format(SHADOW_REQUIRED_PROPERTIES)}.`,
       [ERROR_INVALID_PROP]: 'Unknown property {{ key }}.',
     },
     docs: {

--- a/packages/parser/src/lint/plugin-core/rules/valid-stroke-style.ts
+++ b/packages/parser/src/lint/plugin-core/rules/valid-stroke-style.ts
@@ -20,9 +20,9 @@ const ERROR_INVALID_PROP = 'ERROR_INVALID_PROP';
 const rule: LintRule<typeof ERROR_STR | typeof ERROR_OBJ | typeof ERROR_LINE_CAP | typeof ERROR_INVALID_PROP> = {
   meta: {
     messages: {
-      [ERROR_STR]: `Value most be one of ${new Intl.ListFormat(undefined, { type: 'disjunction' }).format(STROKE_STYLE_STRING_VALUES)}.`,
-      [ERROR_OBJ]: `Missing required properties: ${new Intl.ListFormat(undefined, { type: 'conjunction' }).format(TRANSITION_REQUIRED_PROPERTIES)}.`,
-      [ERROR_LINE_CAP]: `lineCap must be one of ${new Intl.ListFormat(undefined, { type: 'disjunction' }).format(STROKE_STYLE_LINE_CAP_VALUES)}.`,
+      [ERROR_STR]: `Value most be one of ${new Intl.ListFormat('en-us', { type: 'disjunction' }).format(STROKE_STYLE_STRING_VALUES)}.`,
+      [ERROR_OBJ]: `Missing required properties: ${new Intl.ListFormat('en-us', { type: 'conjunction' }).format(TRANSITION_REQUIRED_PROPERTIES)}.`,
+      [ERROR_LINE_CAP]: `lineCap must be one of ${new Intl.ListFormat('en-us', { type: 'disjunction' }).format(STROKE_STYLE_LINE_CAP_VALUES)}.`,
       [ERROR_INVALID_PROP]: 'Unknown property: {{ key }}.',
     },
     docs: {

--- a/packages/parser/src/lint/plugin-core/rules/valid-transition.ts
+++ b/packages/parser/src/lint/plugin-core/rules/valid-transition.ts
@@ -12,7 +12,7 @@ const ERROR_INVALID_PROP = 'ERROR_INVALID_PROP';
 const rule: LintRule<typeof ERROR | typeof ERROR_INVALID_PROP> = {
   meta: {
     messages: {
-      [ERROR]: `Missing required properties: ${new Intl.ListFormat(undefined, { type: 'conjunction' }).format(TRANSITION_REQUIRED_PROPERTIES)}.`,
+      [ERROR]: `Missing required properties: ${new Intl.ListFormat('en-us', { type: 'conjunction' }).format(TRANSITION_REQUIRED_PROPERTIES)}.`,
       [ERROR_INVALID_PROP]: 'Unknown property: {{ key }}.',
     },
     docs: {


### PR DESCRIPTION
## Changes

- fixes: #598

## How to Review

Automated tests pass on non `en_US` locales.