### PR TITLE
Add missing @terrazzo/parser deps

### DIFF
--- a/packages/plugin-css-in-js/package.json
+++ b/packages/plugin-css-in-js/package.json
@@ -46,6 +46,7 @@
   },
   "peerDependencies": {
     "@terrazzo/cli": "workspace:^",
+    "@terrazzo/parser": "workspace:^",
     "@terrazzo/plugin-css": "workspace:^"
   },
   "dependencies": {

--- a/packages/plugin-css/package.json
+++ b/packages/plugin-css/package.json
@@ -36,7 +36,8 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@terrazzo/cli": "workspace:^"
+    "@terrazzo/cli": "workspace:^",
+    "@terrazzo/parser": "workspace:^"
   },
   "dependencies": {
     "@terrazzo/token-tools": "workspace:^",

--- a/packages/plugin-js/package.json
+++ b/packages/plugin-js/package.json
@@ -37,7 +37,8 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@terrazzo/cli": "workspace:^"
+    "@terrazzo/cli": "workspace:^",
+    "@terrazzo/parser": "workspace:^"
   },
   "dependencies": {
     "@terrazzo/parser": "workspace:^",

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -37,6 +37,7 @@
   },
   "peerDependencies": {
     "@terrazzo/cli": "workspace:^",
+    "@terrazzo/parser": "workspace:^",
     "@terrazzo/plugin-css": "workspace:^"
   },
   "dependencies": {

--- a/packages/plugin-swift/package.json
+++ b/packages/plugin-swift/package.json
@@ -35,7 +35,8 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@terrazzo/cli": "workspace:^"
+    "@terrazzo/cli": "workspace:^",
+    "@terrazzo/parser": "workspace:^"
   },
   "dependencies": {
     "@terrazzo/token-tools": "workspace:^",

--- a/packages/plugin-tailwind/package.json
+++ b/packages/plugin-tailwind/package.json
@@ -37,6 +37,7 @@
   },
   "peerDependencies": {
     "@terrazzo/cli": "workspace:^",
+    "@terrazzo/parser": "workspace:^",
     "@terrazzo/plugin-css": "workspace:^",
     "tailwindcss": "^4.0.0"
   },

--- a/packages/plugin-token-listing/package.json
+++ b/packages/plugin-token-listing/package.json
@@ -36,7 +36,8 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@terrazzo/cli": "workspace:^"
+    "@terrazzo/cli": "workspace:^",
+    "@terrazzo/parser": "workspace:^"
   },
   "dependencies": {
     "@terrazzo/token-tools": "workspace:^",

--- a/packages/plugin-vanilla-extract/package.json
+++ b/packages/plugin-vanilla-extract/package.json
@@ -38,6 +38,7 @@
   },
   "peerDependencies": {
     "@terrazzo/cli": "workspace:^",
+    "@terrazzo/parser": "workspace:^",
     "@terrazzo/plugin-css": "workspace:^"
   },
   "dependencies": {


### PR DESCRIPTION
All plugins have either runtime or public type dependencies on @terrazzo/parser (or both).

This was causing errors in yarn pnp as plugins were importing an undeclared dependency.

## Changes

Add `@terrazzo/parser` as peerdep to all plugins

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_
