### PR TITLE
Token transform

### DIFF
--- a/packages/parser/src/parse/process.ts
+++ b/packages/parser/src/parse/process.ts
@@ -1,4 +1,4 @@
-import * as momoa from '@humanwhocodes/momoa';
+import type * as momoa from '@humanwhocodes/momoa';
 import {
   encodeFragment,
   findNode,

--- a/packages/parser/src/resolver/validate.ts
+++ b/packages/parser/src/resolver/validate.ts
@@ -1,4 +1,4 @@
-import * as momoa from '@humanwhocodes/momoa';
+import type * as momoa from '@humanwhocodes/momoa';
 import { getObjMember, getObjMembers } from '@terrazzo/json-schema-tools';
 import type { LogEntry, default as Logger } from '../logger.js';
 

--- a/packages/token-tools/src/css/boolean.ts
+++ b/packages/token-tools/src/css/boolean.ts
@@ -1,14 +1,14 @@
 import type { BooleanTokenNormalized } from '../types.js';
-import type { TransformCSSValueOptions } from './css-types.js';
+import type { StrictTransformCSSValueOptions } from './css-types.js';
 import { defaultAliasTransform } from './lib.js';
 
 /** Convert boolean value to CSS string */
 export function transformBoolean(
   token: BooleanTokenNormalized,
-  { tokensSet, transformAlias = defaultAliasTransform }: TransformCSSValueOptions,
+  { tokensSet, transformAlias = defaultAliasTransform }: StrictTransformCSSValueOptions,
 ): string {
   if (token.aliasChain?.[0]) {
-    return transformAlias(tokensSet[token.aliasChain[0]]!);
+    return transformAlias(tokensSet[token.aliasChain[0]]);
   }
   return token.$value === true ? '1' : '0';
 }

--- a/packages/token-tools/src/css/border.ts
+++ b/packages/token-tools/src/css/border.ts
@@ -6,26 +6,26 @@ import type {
   StrokeStyleTokenNormalized,
 } from '../types.js';
 import { transformColor } from './color.js';
-import type { TransformCSSValueOptions } from './css-types.js';
+import type { StrictTransformCSSValueOptions } from './css-types.js';
 import { transformDimension } from './dimension.js';
 import { defaultAliasTransform } from './lib.js';
 import { transformStrokeStyle } from './stroke-style.js';
 
 /** Convert border value to multiple CSS values */
-export function transformBorder(token: BorderTokenNormalized, options: TransformCSSValueOptions) {
+export function transformBorder(token: BorderTokenNormalized, options: StrictTransformCSSValueOptions) {
   const { tokensSet, transformAlias = defaultAliasTransform } = options;
   if (token.aliasChain?.[0]) {
-    return transformAlias(tokensSet[token.aliasChain[0]]!);
+    return transformAlias(tokensSet[token.aliasChain[0]]);
   }
 
   const width = token.partialAliasOf?.width
-    ? transformAlias(tokensSet[token.partialAliasOf.width]!)
+    ? transformAlias(tokensSet[token.partialAliasOf.width])
     : transformDimension({ $value: token.$value.width } as DimensionTokenNormalized, options);
   const color = token.partialAliasOf?.color
-    ? transformAlias(tokensSet[token.partialAliasOf.color]!)
+    ? transformAlias(tokensSet[token.partialAliasOf.color])
     : transformColor({ $value: token.$value.color } as ColorTokenNormalized, options);
   const style = token.partialAliasOf?.style
-    ? transformAlias(tokensSet[token.partialAliasOf.style]!)
+    ? transformAlias(tokensSet[token.partialAliasOf.style])
     : transformStrokeStyle({ $value: token.$value.style } as StrokeStyleTokenNormalized, options);
 
   const formatBorder = (colorKey: string) =>

--- a/packages/token-tools/src/css/color.ts
+++ b/packages/token-tools/src/css/color.ts
@@ -26,7 +26,7 @@ import {
 } from 'culori/fn';
 import { CSS_TO_CULORI, type CULORI_TO_CSS, parseColor, tokenToCulori } from '../color.js';
 import type { ColorTokenNormalized } from '../types.js';
-import type { TransformCSSValueOptions } from './css-types.js';
+import type { StrictTransformCSSValueOptions } from './css-types.js';
 import { defaultAliasTransform } from './lib.js';
 
 export type WideGamutColorValue = {
@@ -39,11 +39,11 @@ export type WideGamutColorValue = {
 /** Convert color value to CSS string */
 export function transformColor(
   token: ColorTokenNormalized,
-  options: TransformCSSValueOptions,
+  options: StrictTransformCSSValueOptions,
 ): string | WideGamutColorValue {
   const { transformAlias = defaultAliasTransform, tokensSet } = options;
   if (token.aliasChain?.[0]) {
-    return transformAlias(tokensSet[token.aliasChain[0]]!);
+    return transformAlias(tokensSet[token.aliasChain[0]]);
   }
 
   const {

--- a/packages/token-tools/src/css/css-types.ts
+++ b/packages/token-tools/src/css/css-types.ts
@@ -1,5 +1,5 @@
 import type { TokenNormalizedSet } from '../types.js';
-import type { IDGenerator } from './lib.js';
+import type { IDGenerator, StrictIDGenerator } from './lib.js';
 
 export interface TransformCSSValueOptions {
   /** Complete set of tokens (needed to resolve full and partial aliases) */
@@ -15,4 +15,8 @@ export interface TransformCSSValueOptions {
      */
     depth?: 24 | 30 | 36 | 48 | 'unlimited';
   };
+}
+
+export interface StrictTransformCSSValueOptions extends TransformCSSValueOptions {
+  transformAlias?: StrictIDGenerator;
 }

--- a/packages/token-tools/src/css/cubic-bezier.ts
+++ b/packages/token-tools/src/css/cubic-bezier.ts
@@ -1,14 +1,17 @@
 import type { CubicBezierTokenNormalized } from '../types.js';
-import type { TransformCSSValueOptions } from './css-types.js';
+import type { StrictTransformCSSValueOptions } from './css-types.js';
 import { defaultAliasTransform } from './lib.js';
 
 /** Convert cubicBezier value to CSS */
-export function transformCubicBezier(token: CubicBezierTokenNormalized, options: TransformCSSValueOptions): string {
+export function transformCubicBezier(
+  token: CubicBezierTokenNormalized,
+  options: StrictTransformCSSValueOptions,
+): string {
   const { tokensSet, transformAlias = defaultAliasTransform } = options;
   if (token.aliasChain?.[0]) {
-    return transformAlias(tokensSet[token.aliasChain[0]]!);
+    return transformAlias(tokensSet[token.aliasChain[0]]);
   }
   return `cubic-bezier(${token.$value
-    .map((v, i) => (token.partialAliasOf?.[i] ? transformAlias(tokensSet[token.partialAliasOf[i]]!) : v))
+    .map((v, i) => (token.partialAliasOf?.[i] ? transformAlias(tokensSet[token.partialAliasOf[i]]) : v))
     .join(', ')})`;
 }

--- a/packages/token-tools/src/css/dimension.ts
+++ b/packages/token-tools/src/css/dimension.ts
@@ -1,12 +1,12 @@
 import type { DimensionTokenNormalized } from '../types.js';
-import type { TransformCSSValueOptions } from './css-types.js';
+import type { StrictTransformCSSValueOptions } from './css-types.js';
 import { defaultAliasTransform } from './lib.js';
 
 /** Convert dimension value to CSS */
-export function transformDimension(token: DimensionTokenNormalized, options: TransformCSSValueOptions): string {
+export function transformDimension(token: DimensionTokenNormalized, options: StrictTransformCSSValueOptions): string {
   const { tokensSet, transformAlias = defaultAliasTransform } = options;
   if (token.aliasChain?.[0]) {
-    return transformAlias(tokensSet[token.aliasChain[0]]!);
+    return transformAlias(tokensSet[token.aliasChain[0]]);
   }
 
   return token.$value.value === 0 ? '0' : `${token.$value.value}${token.$value.unit}`;

--- a/packages/token-tools/src/css/duration.ts
+++ b/packages/token-tools/src/css/duration.ts
@@ -1,12 +1,12 @@
 import type { DurationTokenNormalized } from '../types.js';
-import type { TransformCSSValueOptions } from './css-types.js';
+import type { StrictTransformCSSValueOptions } from './css-types.js';
 import { defaultAliasTransform } from './lib.js';
 
 /** Convert duration value to CSS */
-export function transformDuration(token: DurationTokenNormalized, options: TransformCSSValueOptions): string {
+export function transformDuration(token: DurationTokenNormalized, options: StrictTransformCSSValueOptions): string {
   const { tokensSet, transformAlias = defaultAliasTransform } = options;
   if (token.aliasChain?.[0]) {
-    return transformAlias(tokensSet[token.aliasChain[0]]!);
+    return transformAlias(tokensSet[token.aliasChain[0]]);
   }
 
   return `${token.$value.value}${token.$value.unit}`;

--- a/packages/token-tools/src/css/font-family.ts
+++ b/packages/token-tools/src/css/font-family.ts
@@ -1,13 +1,13 @@
 import type { FontFamilyTokenNormalized } from '../types.js';
-import type { TransformCSSValueOptions } from './css-types.js';
+import type { StrictTransformCSSValueOptions } from './css-types.js';
 import { defaultAliasTransform } from './lib.js';
 
 const FONT_NAME_KEYWORD = /^[a-z-]+$/;
 
-export function transformFontFamily(token: FontFamilyTokenNormalized, options: TransformCSSValueOptions): string {
+export function transformFontFamily(token: FontFamilyTokenNormalized, options: StrictTransformCSSValueOptions): string {
   const { tokensSet, transformAlias = defaultAliasTransform } = options;
   if (token.aliasChain?.[0]) {
-    return transformAlias(tokensSet[token.aliasChain[0]]!);
+    return transformAlias(tokensSet[token.aliasChain[0]]);
   }
   return token.$value.map((fontName) => (FONT_NAME_KEYWORD.test(fontName) ? fontName : `"${fontName}"`)).join(', ');
 }

--- a/packages/token-tools/src/css/font-weight.ts
+++ b/packages/token-tools/src/css/font-weight.ts
@@ -1,12 +1,12 @@
 import type { FontWeightTokenNormalized } from '../types.js';
-import type { TransformCSSValueOptions } from './css-types.js';
+import type { StrictTransformCSSValueOptions } from './css-types.js';
 import { defaultAliasTransform } from './lib.js';
 
 /** Convert fontWeight value to CSS */
-export function transformFontWeight(token: FontWeightTokenNormalized, options: TransformCSSValueOptions): string {
+export function transformFontWeight(token: FontWeightTokenNormalized, options: StrictTransformCSSValueOptions): string {
   const { tokensSet, transformAlias = defaultAliasTransform } = options;
   if (token.aliasChain?.[0]) {
-    return transformAlias(tokensSet[token.aliasChain[0]]!);
+    return transformAlias(tokensSet[token.aliasChain[0]]);
   }
   return String(token.$value);
 }

--- a/packages/token-tools/src/css/gradient.ts
+++ b/packages/token-tools/src/css/gradient.ts
@@ -1,16 +1,16 @@
 import type { ColorTokenNormalized, GradientTokenNormalized } from '../types.js';
 import { transformColor, type WideGamutColorValue } from './color.js';
-import type { TransformCSSValueOptions } from './css-types.js';
+import type { StrictTransformCSSValueOptions } from './css-types.js';
 import { defaultAliasTransform } from './lib.js';
 
 /** Convert gradient value to CSS */
 export function transformGradient(
   token: GradientTokenNormalized,
-  options: TransformCSSValueOptions,
+  options: StrictTransformCSSValueOptions,
 ): string | WideGamutColorValue {
   const { tokensSet, transformAlias = defaultAliasTransform } = options;
   if (token.aliasChain?.[0]) {
-    return transformAlias(tokensSet[token.aliasChain[0]]!);
+    return transformAlias(tokensSet[token.aliasChain[0]]);
   }
 
   let isHDR = false;
@@ -21,7 +21,7 @@ export function transformGradient(
   for (let i = 0; i < token.$value.length; i++) {
     const { color, position } = token.$value[i]!;
     const colorValue = token.partialAliasOf?.[i]?.color
-      ? transformAlias(tokensSet[token.partialAliasOf[i]!.color!]!)
+      ? transformAlias(tokensSet[token.partialAliasOf![i]!.color!])
       : transformColor({ $value: color } as ColorTokenNormalized, options);
     if (typeof colorValue !== 'string') {
       isHDR = true;
@@ -29,7 +29,7 @@ export function transformGradient(
     colors.push(colorValue);
     positions.push(
       token.partialAliasOf?.[i]?.position
-        ? transformAlias(tokensSet[token.partialAliasOf[i]!.position!]!)
+        ? transformAlias(tokensSet[token.partialAliasOf[i]!.position!])
         : `${100 * position}%`,
     );
   }

--- a/packages/token-tools/src/css/index.ts
+++ b/packages/token-tools/src/css/index.ts
@@ -2,13 +2,14 @@ import type { TokenNormalized } from '../types.js';
 import { transformBoolean } from './boolean.js';
 import { transformBorder } from './border.js';
 import { transformColor } from './color.js';
-import type { TransformCSSValueOptions } from './css-types.js';
+import type { StrictTransformCSSValueOptions, TransformCSSValueOptions } from './css-types.js';
 import { transformCubicBezier } from './cubic-bezier.js';
 import { transformDimension } from './dimension.js';
 import { transformDuration } from './duration.js';
 import { transformFontFamily } from './font-family.js';
 import { transformFontWeight } from './font-weight.js';
 import { transformGradient } from './gradient.js';
+import { defaultAliasTransform } from './lib.js';
 import { transformLink } from './link.js';
 import { transformNumber } from './number.js';
 import { transformShadow } from './shadow.js';
@@ -38,12 +39,22 @@ export * from './typography.js';
 /** Main CSS Transform */
 export function transformCSSValue<T extends TokenNormalized = TokenNormalized>(
   token: T,
-  { mode, ...options }: { mode: keyof T['mode'] } & TransformCSSValueOptions,
+  { mode, transformAlias = defaultAliasTransform, ...rest }: { mode: keyof T['mode'] } & TransformCSSValueOptions,
 ) {
   const selectedMode = token.mode[mode as keyof typeof token.mode];
   if (!selectedMode) {
     return;
   }
+
+  const options: StrictTransformCSSValueOptions = {
+    transformAlias: (token) => {
+      if (!token) {
+        throw new Error('Undefined token');
+      }
+      return transformAlias(token);
+    },
+    ...rest,
+  };
   const tokenWithModeValue: T = {
     id: token.id,
     $type: token.$type,

--- a/packages/token-tools/src/css/lib.ts
+++ b/packages/token-tools/src/css/lib.ts
@@ -1,9 +1,14 @@
 import type { TokenNormalized } from '../types.js';
 
+/**
+ * Function that generates a var(…) statement
+ * Will throw error if token not provided
+ * */
+export type StrictIDGenerator<T = TokenNormalized> = (token: T | undefined) => string;
 /** Function that generates a var(…) statement */
 export type IDGenerator<T = TokenNormalized> = (token: T) => string;
 
-export function defaultAliasTransform(token: TokenNormalized) {
+export function defaultAliasTransform(token: TokenNormalized | undefined) {
   if (!token) {
     throw new Error('Undefined token');
   }

--- a/packages/token-tools/src/css/link.ts
+++ b/packages/token-tools/src/css/link.ts
@@ -1,12 +1,12 @@
 import type { LinkTokenNormalized } from '../types.js';
-import type { TransformCSSValueOptions } from './css-types.js';
+import type { StrictTransformCSSValueOptions } from './css-types.js';
 import { defaultAliasTransform } from './lib.js';
 
 /** Convert link value to CSS */
-export function transformLink(token: LinkTokenNormalized, options: TransformCSSValueOptions): string {
+export function transformLink(token: LinkTokenNormalized, options: StrictTransformCSSValueOptions): string {
   const { tokensSet, transformAlias = defaultAliasTransform } = options;
   if (token.aliasChain?.[0]) {
-    return transformAlias(tokensSet[token.aliasChain[0]]!);
+    return transformAlias(tokensSet[token.aliasChain[0]]);
   }
   return `url("${token.$value}")`;
 }

--- a/packages/token-tools/src/css/number.ts
+++ b/packages/token-tools/src/css/number.ts
@@ -1,12 +1,12 @@
 import type { NumberTokenNormalized } from '../types.js';
-import type { TransformCSSValueOptions } from './css-types.js';
+import type { StrictTransformCSSValueOptions } from './css-types.js';
 import { defaultAliasTransform } from './lib.js';
 
 /** Convert number value to CSS */
-export function transformNumber(token: NumberTokenNormalized, options: TransformCSSValueOptions): string {
+export function transformNumber(token: NumberTokenNormalized, options: StrictTransformCSSValueOptions): string {
   const { tokensSet, transformAlias = defaultAliasTransform } = options;
   if (token.aliasChain?.[0]) {
-    return transformAlias(tokensSet[token.aliasChain[0]]!);
+    return transformAlias(tokensSet[token.aliasChain[0]]);
   }
   return String(token.$value);
 }

--- a/packages/token-tools/src/css/shadow.ts
+++ b/packages/token-tools/src/css/shadow.ts
@@ -5,30 +5,30 @@ import type {
   ShadowValueNormalized,
 } from '../types.js';
 import { transformColor } from './color.js';
-import type { TransformCSSValueOptions } from './css-types.js';
+import type { StrictTransformCSSValueOptions } from './css-types.js';
 import { transformDimension } from './dimension.js';
 import { defaultAliasTransform } from './lib.js';
 
 /** Convert shadow subvalue to CSS */
 export function transformShadowLayer(
   value: ShadowValueNormalized,
-  options: TransformCSSValueOptions & {
+  options: StrictTransformCSSValueOptions & {
     colorValue: string;
     partialAliasOf?: Partial<Record<keyof typeof value, string>>;
   },
 ): string | Record<string, string> {
   const { tokensSet, colorValue, partialAliasOf, transformAlias = defaultAliasTransform } = options;
   const offsetX = partialAliasOf?.offsetX
-    ? transformAlias(tokensSet[partialAliasOf.offsetX]!)
+    ? transformAlias(tokensSet[partialAliasOf.offsetX])
     : transformDimension({ $value: value.offsetX } as DimensionTokenNormalized, options);
   const offsetY = partialAliasOf?.offsetY
-    ? transformAlias(tokensSet[partialAliasOf.offsetY]!)
+    ? transformAlias(tokensSet[partialAliasOf.offsetY])
     : transformDimension({ $value: value.offsetY } as DimensionTokenNormalized, options);
   const blur = partialAliasOf?.blur
-    ? transformAlias(tokensSet[partialAliasOf.blur]!)
+    ? transformAlias(tokensSet[partialAliasOf.blur])
     : transformDimension({ $value: value.blur } as DimensionTokenNormalized, options);
   const spread = partialAliasOf?.spread
-    ? transformAlias(tokensSet[partialAliasOf.spread]!)
+    ? transformAlias(tokensSet[partialAliasOf.spread])
     : transformDimension({ $value: value.spread } as DimensionTokenNormalized, options);
   const inset = value?.inset === true ? 'inset' : undefined;
 
@@ -38,15 +38,15 @@ export function transformShadowLayer(
 /** Convert shadow value to CSS */
 export function transformShadow(
   token: ShadowTokenNormalized,
-  options: TransformCSSValueOptions,
+  options: StrictTransformCSSValueOptions,
 ): string | Record<string, string> {
   const { tokensSet, transformAlias = defaultAliasTransform } = options;
   if (token.aliasChain?.[0]) {
-    return transformAlias(tokensSet[token.aliasChain[0]]!);
+    return transformAlias(tokensSet[token.aliasChain[0]]);
   }
   const colors = token.$value.map((v, i) =>
     token.partialAliasOf?.[i]?.color
-      ? transformAlias(tokensSet[token.partialAliasOf[i]!.color!]!)
+      ? transformAlias(tokensSet[token.partialAliasOf[i]!.color!])
       : transformColor({ $value: v.color } as ColorTokenNormalized, options),
   );
   const isHDR = colors.some((c) => typeof c === 'object');

--- a/packages/token-tools/src/css/string.ts
+++ b/packages/token-tools/src/css/string.ts
@@ -1,12 +1,12 @@
 import type { StringTokenNormalized } from '../types.js';
-import type { TransformCSSValueOptions } from './css-types.js';
+import type { StrictTransformCSSValueOptions } from './css-types.js';
 import { defaultAliasTransform } from './lib.js';
 
 /** Convert string value to CSS */
-export function transformString(token: StringTokenNormalized, options: TransformCSSValueOptions): string {
+export function transformString(token: StringTokenNormalized, options: StrictTransformCSSValueOptions): string {
   const { tokensSet, transformAlias = defaultAliasTransform } = options;
   if (token.aliasChain?.[0]) {
-    return transformAlias(tokensSet[token.aliasChain[0]]!);
+    return transformAlias(tokensSet[token.aliasChain[0]]);
   }
   // this seems like a useless function—because it is—but this is a placeholder
   // that can handle unexpected values in the future should any arise

--- a/packages/token-tools/src/css/stroke-style.ts
+++ b/packages/token-tools/src/css/stroke-style.ts
@@ -1,12 +1,15 @@
 import type { StrokeStyleTokenNormalized } from '../types.js';
-import type { TransformCSSValueOptions } from './css-types.js';
+import type { StrictTransformCSSValueOptions } from './css-types.js';
 import { defaultAliasTransform } from './lib.js';
 
 /** Convert strokeStyle value to CSS */
-export function transformStrokeStyle(token: StrokeStyleTokenNormalized, options: TransformCSSValueOptions): string {
+export function transformStrokeStyle(
+  token: StrokeStyleTokenNormalized,
+  options: StrictTransformCSSValueOptions,
+): string {
   const { tokensSet, transformAlias = defaultAliasTransform } = options;
   if (token.aliasChain?.[0]) {
-    return transformAlias(tokensSet[token.aliasChain[0]]!);
+    return transformAlias(tokensSet[token.aliasChain[0]]);
   }
   return typeof token.$value === 'string' ? token.$value : 'dashed'; // CSS doesn’t have `dash-array`; it’s just "dashed"
 }

--- a/packages/token-tools/src/css/transition.ts
+++ b/packages/token-tools/src/css/transition.ts
@@ -1,24 +1,24 @@
 import type { CubicBezierTokenNormalized, DurationTokenNormalized, TransitionTokenNormalized } from '../types.js';
-import type { TransformCSSValueOptions } from './css-types.js';
+import type { StrictTransformCSSValueOptions } from './css-types.js';
 import { transformCubicBezier } from './cubic-bezier.js';
 import { transformDuration } from './duration.js';
 import { defaultAliasTransform } from './lib.js';
 
 /** Convert transition value to shorthand */
-export function transformTransition(token: TransitionTokenNormalized, options: TransformCSSValueOptions) {
+export function transformTransition(token: TransitionTokenNormalized, options: StrictTransformCSSValueOptions) {
   const { tokensSet, transformAlias = defaultAliasTransform } = options;
   if (token.aliasChain?.[0]) {
-    return transformAlias(tokensSet[token.aliasChain[0]]!);
+    return transformAlias(tokensSet[token.aliasChain[0]]);
   }
 
   const duration = token.partialAliasOf?.duration
-    ? transformAlias(tokensSet[token.partialAliasOf.duration]!)
+    ? transformAlias(tokensSet[token.partialAliasOf.duration])
     : transformDuration({ $value: token.$value.duration } as DurationTokenNormalized, options);
   const delay = token.partialAliasOf?.delay
-    ? transformAlias(tokensSet[token.partialAliasOf.delay]!)
+    ? transformAlias(tokensSet[token.partialAliasOf.delay])
     : transformDuration({ $value: token.$value.delay } as DurationTokenNormalized, options);
   const timingFunction = token.partialAliasOf?.timingFunction
-    ? transformAlias(tokensSet[token.partialAliasOf.timingFunction]!)
+    ? transformAlias(tokensSet[token.partialAliasOf.timingFunction])
     : transformCubicBezier({ $value: token.$value.timingFunction } as CubicBezierTokenNormalized, options);
 
   return `${duration} ${delay} ${timingFunction}`;

--- a/packages/token-tools/src/css/typography.ts
+++ b/packages/token-tools/src/css/typography.ts
@@ -8,7 +8,7 @@ import type {
   TokenNormalized,
   TypographyTokenNormalized,
 } from '../types.js';
-import type { TransformCSSValueOptions } from './css-types.js';
+import type { StrictTransformCSSValueOptions } from './css-types.js';
 import { transformDimension } from './dimension.js';
 import { transformFontFamily } from './font-family.js';
 import { transformFontWeight } from './font-weight.js';
@@ -17,7 +17,7 @@ import { transformNumber } from './number.js';
 import { transformString } from './string.js';
 
 /** Convert typography value to multiple CSS values */
-export function transformTypography(token: TypographyTokenNormalized, options: TransformCSSValueOptions) {
+export function transformTypography(token: TypographyTokenNormalized, options: StrictTransformCSSValueOptions) {
   const { tokensSet, transformAlias = defaultAliasTransform } = options;
   const output: Record<string, string> = {};
   for (const [property, subvalue] of Object.entries(token.$value)) {


### PR DESCRIPTION
## Changes

Reworking of #621 

I realised that the default `transformAlias` does throw errors on undefined:

https://github.com/terrazzoapp/terrazzo/blob/8cb471e3cd8468fbf8d47c454344c00fb0a78d83/packages/token-tools/src/css/lib.ts#L6-L9

However, when a user-provided function is given, this assertion is lost.

Instead of having to update every transform, update the entrypoint to wrap any user-provided `transformAlias` with an assertion. This means we can burn a lot more `!`.



## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_
