### PR TITLE
Make tokenset throw error when accessing invalid token

### DIFF
--- a/packages/parser/src/parse/index.ts
+++ b/packages/parser/src/parse/index.ts
@@ -100,7 +100,18 @@ export default async function parse(
   }
 
   return {
-    tokens,
+    tokens: new Proxy(tokens, {
+      get(target, p: string): any {
+        const resolved = target[p];
+        if (!resolved) {
+          logger.error({
+            group: 'parser',
+            message: `Unable to resolve alias ${p}`,
+          });
+        }
+        return resolved;
+      },
+    }),
     sources,
     resolver: finalResolver,
   };

--- a/packages/parser/src/parse/process.ts
+++ b/packages/parser/src/parse/process.ts
@@ -1,4 +1,4 @@
-import * as momoa from '@humanwhocodes/momoa';
+import type * as momoa from '@humanwhocodes/momoa';
 import {
   encodeFragment,
   findNode,

--- a/packages/parser/src/resolver/validate.ts
+++ b/packages/parser/src/resolver/validate.ts
@@ -1,4 +1,4 @@
-import * as momoa from '@humanwhocodes/momoa';
+import type * as momoa from '@humanwhocodes/momoa';
 import { getObjMember, getObjMembers } from '@terrazzo/json-schema-tools';
 import type { LogEntry, default as Logger } from '../logger.js';
 


### PR DESCRIPTION
Another approach to #623 - wrap `tokenSet` in a proxy that logs an error using the provided logger when attempting to access a non-existant token.