### PR TITLE
[docs] Fix string type extension code sample

### DIFF
--- a/www/src/pages/docs/reference/tokens.md
+++ b/www/src/pages/docs/reference/tokens.md
@@ -338,7 +338,7 @@ Refer to each plugin’s documentation to learn what special features are availa
 ```json
 {
   "myCustomValue": {
-    "$type": "boolean",
+    "$type": "string",
     "$value": ""
   }
 }


### PR DESCRIPTION
## Changes

Fix the code sample for the string type extension, that currently show `"boolean"`.

## How to Review

Just have a look at https://terrazzo.app/docs/reference/tokens/#string-extension to confirm.   
