### PR TITLE
Add missing CSS logical property directions for utility class generation

### DIFF
--- a/packages/plugin-css/src/build/utility-css.ts
+++ b/packages/plugin-css/src/build/utility-css.ts
@@ -164,11 +164,11 @@ export default function generateUtilityCSS(
             output.push(
               {
                 selectors: [makeSelector(token, prefix, 'x')],
-                declarations: { [`${property}-left`]: value, [`${property}-right`]: value },
+                declarations: { [`${property}-inline`]: value, [`${property}-left`]: value, [`${property}-right`]: value },
               },
               {
                 selectors: [makeSelector(token, prefix, 'y')],
-                declarations: { [`${property}-bottom`]: value, [`${property}-top`]: value },
+                declarations: { [`${property}-block`]: value, [`${property}-bottom`]: value, [`${property}-top`]: value },
               },
             );
           }
@@ -183,9 +183,11 @@ export default function generateUtilityCSS(
           for (const token of filteredTokens) {
             const value = makeVarValue(token);
             output.push(
-              { selectors: [makeSelector(token, prefix, 's')], declarations: { [`${property}-inline-start`]: value } },
-              { selectors: [makeSelector(token, prefix, 'e')], declarations: { [`${property}-inline-end`]: value } },
-            );
+							{ selectors: [makeSelector(token, prefix, 'bs')], declarations: { [`${property}-block-start`]: value } },
+							{ selectors: [makeSelector(token, prefix, 'be')], declarations: { [`${property}-block-end`]: value } },
+							{ selectors: [makeSelector(token, prefix, 'is')], declarations: { [`${property}-inline-start`]: value } },
+							{ selectors: [makeSelector(token, prefix, 'ie')], declarations: { [`${property}-inline-end`]: value } },
+						);
           }
         }
         break;


### PR DESCRIPTION
## Changes

Issue: https://github.com/terrazzoapp/terrazzo/issues/617

- Add new base-level `margin|padding-block` and `margin|padding-inline` utility classes
- Adds missing `block-start` and `block-end` utility classes
- Renames existing `inline-start` and `inline-end` classes

## How to Review

> [!NOTE]
> I've set this as draft as there's still some kinks to iron out but I wanted to jumpstart this.
> 
> Primarily, combining `margin|padding-block|inline` adjacent to `margin|padding-top|bottom` is duplicative which is maybe okay, but needs additional thought. Also worth considering is whether there's potential confusion with the new `bs|be` classes and the fact that `b` is already used for "bottom" in most cases.

Testing is adding utility generation to a test token set and confirming the addition of new declarations within the `x` and `y` space utility classes and the net-new classes for `bs|be|is|ie`.
