### PR TITLE
Link to Nick's GitHub profile is broken

### DIFF
--- a/www/src/pages/docs/reference/about.md
+++ b/www/src/pages/docs/reference/about.md
@@ -5,7 +5,7 @@ layout: ../../../layouts/docs.astro
 
 # About Terrazzo
 
-Terrazzo is a free, MIT-licensed open-source design tool built by <a class="gh-user" href="https://github.com/drwpow"><img class="gh-avatar" src="https://avatars.githubusercontent.com/u/1369770?v=4" aria-hidden />@drwpow</a>, <a class="gh-user" href="https://github.com/natassone"><img class="gh-avatar" src="https://avatars.githubusercontent.com/u/1572205?v=4" aria-hidden />@ntassone</a>, and [many other contributors](https://github.com/drwpow/cobalt-ui).
+Terrazzo is a free, MIT-licensed open-source design tool built by <a class="gh-user" href="https://github.com/drwpow"><img class="gh-avatar" src="https://avatars.githubusercontent.com/u/1369770?v=4" aria-hidden />@drwpow</a>, <a class="gh-user" href="https://github.com/ntassone"><img class="gh-avatar" src="https://avatars.githubusercontent.com/u/1572205?v=4" aria-hidden />@ntassone</a>, and [many other contributors](https://github.com/drwpow/cobalt-ui).
 
 It started out as “Cobalt” in 2021 as tooling for the [W3C Design Token Community Group (DTCG)](https://designtokens.org) format. It was clear early on that a visual token editor was needed, but Drew found the CLI to be as big of a project as he could handle on his own. So along came Nick to design and envision Token Lab in 2024.
 


### PR DESCRIPTION
## Changes

Fixes a broken link in the about page.

## How to Review

- Current link 404's: https://github.com/natassone
- Correct link: https://github.com/ntassone

