### PR TITLE
Add version switcher

### DIFF
--- a/packages/tiles/src/Select/Select.css
+++ b/packages/tiles/src/Select/Select.css
@@ -45,16 +45,22 @@
 .tz-select-item-inner {
   --tz-select-icon-size: 1rem;
 
-  display: grid;
+  display: flex;
   gap: var(--tz-space-200);
-  grid-template-columns: var(--tz-select-icon-size) max-content;
 }
 
 .tz-select-item-icon {
   align-content: center;
   align-self: center;
   display: flex;
+  flex: 0 0 auto;
+  min-width: var(--tz-select-icon-size);
   opacity: 0.5;
+  width: var(--tz-select-icon-size);
+
+  .tz-select-trigger &:empty {
+    display: none;
+  }
 }
 
 .tz-select-item-label {
@@ -66,10 +72,12 @@
   align-items: center;
   background-color: var(--tz-color-bg-1);
   display: inline-flex;
+  height: 100%;
   justify-content: center;
   left: 0;
   position: absolute;
   width: var(--tz-space-control-m);
+  z-index: 2;
 }
 
 .tz-select-options {

--- a/packages/tiles/src/Select/Select.tsx
+++ b/packages/tiles/src/Select/Select.tsx
@@ -32,15 +32,15 @@ export interface SelectItemProps extends RadixSelectItemProps {
 export function SelectItem({ className, children, icon, ref, ...rest }: SelectItemProps) {
   return (
     <RadixSelectItem ref={ref} className={clsx('tz-select-item', className)} {...rest}>
+      <SelectItemIndicator className='tz-select-item-indicator'>
+        <Check />
+      </SelectItemIndicator>
       <SelectItemText>
         <span className='tz-select-item-inner'>
           <span className='tz-select-item-icon'>{icon}</span>
           <span className='tz-select-item-label'>{children}</span>
         </span>
       </SelectItemText>
-      <SelectItemIndicator className='tz-select-item-indicator'>
-        <Check />
-      </SelectItemIndicator>
     </RadixSelectItem>
   );
 }

--- a/www/src/components/VersionSwitcher.tsx
+++ b/www/src/components/VersionSwitcher.tsx
@@ -1,0 +1,25 @@
+import { Select, SelectItem } from '@terrazzo/tiles';
+
+export default function VersionSwitcher() {
+  const value = globalThis.location && globalThis.location.pathname.includes('/2.0/') ? '2' : '0';
+
+  return (
+    <Select
+      value={value}
+      onValueChange={(newValue) => {
+        if (newValue === value) {
+          return;
+        }
+        if (newValue === '2') {
+          globalThis.location.href = globalThis.location.href.replace(/\/docs\/?/, '/docs/2.0/');
+        } else {
+          globalThis.location.href = globalThis.location.href.replace(/\/docs\/[\d.]+\/?/, '/docs/');
+        }
+      }}
+      aria-label='Version'
+    >
+      <SelectItem value='0'>Latest</SelectItem>
+      <SelectItem value='2'>2.0 beta</SelectItem>
+    </Select>
+  );
+}

--- a/www/src/components/docs-header-nav.astro
+++ b/www/src/components/docs-header-nav.astro
@@ -3,6 +3,7 @@ import { DiscordLogo, GitHubLogo } from '@terrazzo/icons';
 import SearchBox from './SearchBox.js';
 import ThemeSwitcher from './ThemeSwitcher.js';
 import Terrazzo from './terrazzo.astro';
+import VersionSwitcher from './VersionSwitcher.js';
 ---
 
 <div class="header-nav">
@@ -14,10 +15,18 @@ import Terrazzo from './terrazzo.astro';
         <ThemeSwitcher client:load />
       </li>
       <li>
-        <a href="https://github.com/terrazzoapp/terrazzo" title="Terrazzo on GitHub"><GitHubLogo /></a>
+        <VersionSwitcher client:load />
       </li>
       <li>
-        <a href="https://discord.gg/cju3dXyHNd" title="Join Terrazzo on Discord"><DiscordLogo /></a>
+        <a
+          href="https://github.com/terrazzoapp/terrazzo"
+          title="Terrazzo on GitHub"><GitHubLogo /></a
+        >
+      </li>
+      <li>
+        <a href="https://discord.gg/cju3dXyHNd" title="Join Terrazzo on Discord"
+          ><DiscordLogo /></a
+        >
       </li>
     </ul>
   </nav>
@@ -25,18 +34,22 @@ import Terrazzo from './terrazzo.astro';
 
 <style>
   .header-nav {
-    align-items: center;
+    --nav-height: var(--grid-size);
+
     background-color: var(--tz-color-bg-1);
     border-top: 1px solid var(--grid-color);
     border-bottom: 1px solid var(--grid-color);
     color: var(--tz-color-text-1);
-    display: flex;
-    max-height: var(--grid-size);
-    padding-inline-end: var(--tz-space-500);
+    display: grid;
+    grid-template-columns: 1fr 1fr;
     width: 100%;
 
     @media (width >= 900px) {
+      align-items: center;
       border-top: none;
+      display: flex;
+      max-height: var(--grid-size);
+      padding-inline-end: var(--tz-space-500);
     }
   }
 
@@ -53,19 +66,24 @@ import Terrazzo from './terrazzo.astro';
     }
   }
 
-  .search {
-  }
-
   .nav {
     align-items: center;
-    flex-grow: 0 0 auto;
+    border-top: 1px solid var(--grid-color);
     display: flex;
-    justify-content: flex-end;
+    grid-column: span 2;
+    justify-content: space-between;
     margin-inline-start: auto;
+    padding-inline: var(--tz-space-200);
     position: relative;
+    width: 100%;
 
     @media (width >= 750px) {
+      border-top: none;
       border-inline-start: 1px solid var(--grid-color);
+      flex: 0 0 auto;
+      justify-content: flex-end;
+      padding-inline-start: var(--tz-space-200);
+      width: auto;
     }
 
     ul {
@@ -74,6 +92,7 @@ import Terrazzo from './terrazzo.astro';
       list-style: none;
       margin: 0;
       padding: 0;
+      width: 100%;
 
       @media (width >= 750px) {
         gap: var(--tz-space-300);

--- a/www/src/components/main-nav.astro
+++ b/www/src/components/main-nav.astro
@@ -1,11 +1,7 @@
 ---
-import fs from 'node:fs';
 import { DiscordLogo, GitHubLogo } from '@terrazzo/icons';
 import { ButtonLink } from '@terrazzo/tiles';
 import Terrazzo from './terrazzo.astro';
-
-// const pkgInfo = JSON.parse(fs.readFileSync(new URL('../../../packages/cli/package.json', import.meta.url), 'utf8'));
-// const { version } = pkgInfo;
 ---
 
 <nav class="nav" aria-label="Main">
@@ -16,13 +12,6 @@ import Terrazzo from './terrazzo.astro';
     <li class="nav-item"><a href="/docs">Docs</a></li>
     <li class="nav-item nav-item--sub" style="margin-bottom:-1px">
       <ButtonLink href="/docs" variant="lime">Get Started</ButtonLink>
-    </li>
-    <li class="nav-item nav-item--sub">
-      <a
-        class="nav-link"
-        href="https://github.com/terrazzoapp/terrazzo/releases"
-        ><code class="version">v0.10.3</code></a
-      >
     </li>
     <li class="nav-item nav-item--sub nav-item--secondary">
       <a
@@ -44,8 +33,6 @@ import Terrazzo from './terrazzo.astro';
 
   <style>
     .nav {
-      --nav-height: var(--grid-size);
-
       background: var(--tz-color-bg-1);
       border-bottom: var(--tz-border-2);
       color: var(--tz-color-text-1);

--- a/www/src/config/pages.ts
+++ b/www/src/config/pages.ts
@@ -45,10 +45,10 @@ export const DOCS_NAV_V2 = [
   {
     title: 'Guides',
     items: [
-      { url: '/docs/guides/dtcg/', title: 'DTCG Tokens' },
-      { url: '/docs/guides/resolvers/', title: 'Resolvers' },
-      { url: '/docs/guides/resolver-contexts/', title: 'Resolver Contexts' },
-      { url: '/docs/guides/styleguide/', title: 'DS Styleguide' },
+      { url: '/docs/2.0/guides/dtcg/', title: 'DTCG Tokens' },
+      { url: '/docs/2.0/guides/resolvers/', title: 'Resolvers' },
+      { url: '/docs/2.0/guides/resolver-contexts/', title: 'Resolver Contexts' },
+      { url: '/docs/2.0/guides/styleguide/', title: 'DS Styleguide' },
       { url: '/docs/2.0/guides/migrating-v2/', title: 'Migrating to 2.x' },
     ],
   },
@@ -59,15 +59,15 @@ export const DOCS_NAV_V2 = [
   {
     title: 'Integrations',
     items: [
-      { url: '/docs/integrations/css/', title: 'CSS' },
-      { url: '/docs/integrations/css-in-js/', title: 'CSS-in-JS' },
-      { url: '/docs/integrations/sass/', title: 'Sass' },
+      { url: '/docs/2.0/integrations/css/', title: 'CSS' },
+      { url: '/docs/2.0/integrations/css-in-js/', title: 'CSS-in-JS' },
+      { url: '/docs/2.0/integrations/sass/', title: 'Sass' },
       { url: '/docs/2.0/integrations/js/', title: 'JS/TS' },
-      { url: '/docs/integrations/swift/', title: 'Swift' },
-      { url: '/docs/integrations/tailwind/', title: 'Tailwind' },
-      { url: '/docs/integrations/vanilla-extract/', title: 'Vanilla Extract' },
-      { url: '/docs/integrations/custom/', title: 'Custom' },
-      { url: '/docs/integrations/token-listing/', title: 'Token Listing' },
+      { url: '/docs/2.0/integrations/swift/', title: 'Swift' },
+      { url: '/docs/2.0/integrations/tailwind/', title: 'Tailwind' },
+      { url: '/docs/2.0/integrations/vanilla-extract/', title: 'Vanilla Extract' },
+      { url: '/docs/2.0/integrations/custom/', title: 'Custom' },
+      { url: '/docs/2.0/integrations/token-listing/', title: 'Token Listing' },
     ],
   },
   {

--- a/www/src/layouts/docs.astro
+++ b/www/src/layouts/docs.astro
@@ -6,6 +6,8 @@ import HeadMeta from '../components/head-meta.astro';
 import '../styles/docs.css';
 
 const { frontmatter } = Astro.props;
+const isBeta = Astro.url.pathname.includes('/docs/2.0');
+const nonBetaVersion = Astro.url.pathname.replace(/\/docs\/2\.0\/?/, '/docs/');
 ---
 
 <html lang="en">
@@ -26,7 +28,33 @@ const { frontmatter } = Astro.props;
         --sidebar-width: calc(5 * (var(--grid-size)));
 
         display: flex;
-        flex-direction: column;;
+        flex-direction: column;
+      }
+
+      .banner {
+        align-items: center;
+        background-color: var(--tz-color-bg-selected);
+        border-bottom: 1px solid var(--tz-color-border-3);
+        color: var(--tz-color-text-onselected);
+        display: flex;
+        font-size: var(--tz-font-label-small-font-size);
+        justify-content: center;
+        left: 0;
+        padding: var(--tz-space-300);
+        position: sticky;
+        text-align: center;
+        top: 0;
+        z-index: calc(var(--tz-layer-nav) - 1);
+        width: 100%;
+
+        @media (width >= 750px) {
+          padding: 0;
+          position: fixed;
+          height: calc(0.5 * var(--grid-size));
+          left: var(--sidebar-width);
+          top: var(--grid-size);
+          width: calc(100% - var(--sidebar-width));
+        }
       }
 
       .docs-header-nav {
@@ -68,7 +96,9 @@ const { frontmatter } = Astro.props;
         padding-inline: calc(0.5 * var(--grid-size));
 
         @media (width >= 900px) {
-          margin-inline-start: calc(var(--sidebar-width) + 2 * var(--grid-size) + 1px);
+          margin-inline-start: calc(
+            var(--sidebar-width) + 2 * var(--grid-size) + 1px
+          );
         }
       }
     </style>
@@ -79,6 +109,16 @@ const { frontmatter } = Astro.props;
         <DocsHeaderNav />
       </header>
       <main class="main">
+        {
+          isBeta && (
+            <div class="banner" role="status">
+              <div>
+                You are viewing the 2.0 beta version of the docs.
+                <a href={nonBetaVersion}>Return to latest</a>
+              </div>
+            </div>
+          )
+        }
         <div class="docs-sidenav">
           <DocsSidenav />
         </div>
@@ -86,7 +126,6 @@ const { frontmatter } = Astro.props;
           <slot />
           <DocsFooterNav />
         </div>
-        <div />
       </main>
     </div>
     <script src="../scripts/copy-code.js"></script>

--- a/www/src/pages/docs/2.0/guides/dtcg.md
+++ b/www/src/pages/docs/2.0/guides/dtcg.md
@@ -1,0 +1,105 @@
+---
+title: DTCG Tokens
+layout: ../../../../layouts/docs.astro
+---
+
+# DTCG Tokens
+
+The <abbr title="Design Tokens Community Group">DTCG</abbr> format is a [W3C Community Group specification](https://www.designtokens.org/) started in 2020 and aims to outline a standard, universal design token format that works for all forms of digital design (including web, print, native apps, and beyond).
+
+DTCG tokens are stored in JSON, and look something like the following:
+
+:::code-group
+
+```json [my-ds.tokens.json]
+{
+  "rebeccapurple": {
+    "$type": "color",
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [0.4, 0.2, 0.6]
+    }
+  }
+}
+```
+
+:::
+
+By storing tokens in a universal format like JSON, you can centrally manage them and generate code for any output target including web and native apps.
+
+## Types
+
+Currently, the DTCG format defines the following types:
+
+| Type                                                | Description                                                                    |
+| :-------------------------------------------------- | :----------------------------------------------------------------------------- |
+| [Color](/docs/reference/tokens#color)               | A flat color.                                                                  |
+| [Dimension](/docs/reference/tokens#dimension)       | A unit for sizing, spacing, etc.                                               |
+| [Font Family](/docs/reference/tokens#font-family)   | A font family, with fallbacks.                                                 |
+| [Font Weight](/docs/reference/tokens#font-weight)   | A font weight, such as normal or bold.                                         |
+| [Duration](/docs/reference/tokens#duration)         | A unit for time.                                                               |
+| [Cubic Bézier](/docs/reference/tokens#cubic-bezier) | A Cubic Bézier for animations.                                                 |
+| [Number](/docs/reference/tokens#number)             | A number without units.                                                        |
+| [Stroke Style](/docs/reference/tokens#stroke)       | A stroke.                                                                      |
+| [Border](/docs/reference/tokens#border)             | An element border style.                                                       |
+| [Transition](/docs/reference/tokens#transition)     | A pairing of timing, duration, and a Cubic Bézier to form an animation.        |
+| [Shadow](/docs/reference/tokens#shadow)             | A drop shadow or inner shadow.                                                 |
+| [Gradient](/docs/reference/tokens#gradient)         | A gradient of colors.                                                          |
+| [Typography](/docs/reference/tokens#typography)     | A complete typographic style, including family, weight, line height, and more. |
+
+In addition, Terrazzo also allows 3 additional custom types: [Link](/docs/reference/tokens), [Boolean](/docs/reference/tokens), and [String](/docs/reference/tokens). But it may require writing your own to take full advantage of these types.
+
+## Hierarchy
+
+DTCG token files are infinitely-nestable to create your token structure. For example, if you had a `color.base.blue.500` token, you’d express it like so:
+
+:::code-group
+
+```jsonc [my-ds.tokens.json]
+{
+  "color": {
+    "base": {
+      "blue": {
+        "500": {
+          /* … */
+        },
+      },
+    },
+  },
+}
+```
+
+:::
+
+By allowing your JSON structure to nest, you avoid errors by **avoiding duplication.** For example, if you had to express your tokens like so:
+
+:::code-group
+
+```jsonc [my-ds.tokens.json]
+{
+  "color.base.blue.100": {
+    /* … */
+  },
+  "color.base.blue.200": {
+    /* … */
+  },
+  "color.base.bleu.300": {
+    /* … */
+  },
+  "color.base.blue.400": {
+    /* … */
+  },
+}
+```
+
+:::
+
+It would be easy to miss the typo of “bleu!” But by declaring every group name once and only once, you make mistakes impossible.
+
+## Format
+
+You can [find the official format here](https://designtokens.org/TR/2025.10/format/). But for convenience, we also have [a list of token types](/docs/reference/tokens) Terrazzo supports.
+
+## Further Reading
+
+- [Official specification (latest version)](https://designtokens.org/TR/2025.10/format/)

--- a/www/src/pages/docs/2.0/guides/resolver-contexts.md
+++ b/www/src/pages/docs/2.0/guides/resolver-contexts.md
@@ -1,0 +1,188 @@
+---
+title: Resolver Contexts (Themes)
+layout: ../../../../layouts/docs.astro
+---
+
+# Resolver Contexts (Themes)
+
+:::info
+
+Contexts is the successor to [legacy modes](#modes-legacy) introduced way back in 2021. Contexts accomplishes the same purposes of theming but in a better package.
+
+:::
+
+Contexts are a way of expressing alternate values of a token, for example color themes like light mode and dark mode. But they can be used for even more, including, but not limited to:
+
+- Color blindness (protanopia/deuteranopia/tritanopia)
+- High contrast mode
+- Text size
+- Screen size
+- Device (mobile/tablet/desktop)
+
+## Setup
+
+The easiest way to consume contexts is to have your JSON tokens separated into different files. For example, let’s say you want to orchestrate **light and dark mode**. You may organize some files like so:
+
+```
+tokens/
+├── foundation/
+│   ├── colors.tokens.json
+│   └── layout.tokens.json
+└── themes/
+    ├── light.tokens.json
+    └── dark.tokens.json
+```
+
+Let’s say within the `foundation/` folder, everything always gets applied—the `colors.tokens.json` and `layout.tokens.json` are consistent no matter what. But the `themes/light.tokens.json` or `themes/dark.tokens.json` may override some values depending on whether a user is in light or dark mode.
+
+As a simple example, let’s just look at how `color.bg` and `color.text` change between light and dark mode:
+
+:::code-group
+
+```json [foundation/colors.tokens.json]
+{
+  "color": {
+    "gray": {
+      "200": {
+        "$value": { "colorSpace": "srgb", "components": [0.82, 0.82, 0.82] },
+        "$type": "color"
+      },
+      "900": {
+        "$value": { "colorSpace": "srgb", "components": [0.04, 0.04, 0.04] },
+        "$type": "color"
+      }
+    }
+  }
+}
+```
+
+```json [theme/light.tokens.json]
+{
+  "color": {
+    "bg": { "$value": "{color.gray.200}", "$type": "color" },
+    "text": { "$value": "{color.gray.900}", "$type": "color" }
+  }
+}
+```
+
+```json [theme/dark.tokens.json]
+{
+  "color": {
+    "bg": { "$value": "{color.gray.900}", "$type": "color" },
+    "text": { "$value": "{color.gray.200}", "$type": "color" }
+  }
+}
+```
+
+:::
+
+Note that `light.tokens.json` and `dark.tokens.json` have aliases to tokens that don’t exist in the same file. In other words, they’re **incomplete** and need more context as to the missing tokens. That’s where a [resolver](#resolver) comes in!
+
+## Resolver
+
+Here’s what a [Resolver](/docs/2.0/guides/resolvers/) example for this system could look like:
+
+:::code-group
+
+```jsonc [my-design-system.resolver.json]
+{
+  "name": "My Design System",
+  "version": "2025.10",
+  "resolutionOrder": [
+    { "$ref": "#/sets/foundation" },
+    { "$ref": "#/modifiers/theme" },
+  ],
+  "sets": {
+    "foundation": {
+      "sources": [
+        { "$ref": "foundation/colors.tokens.json" },
+        { "$ref": "foundation/layout.tokens.json" },
+      ],
+    },
+  },
+  "modifiers": {
+    "theme": {
+      "contexts": {
+        "light": [{ "$ref": "theme/light.tokens.json" }],
+        "dark": [{ "$ref": "theme/dark.tokens.json" }],
+      },
+    },
+  },
+}
+```
+
+:::
+
+Remember from [the previous guide](/docs/2.0/guides/resolvers/#resolutionorder) how resolution order works:
+
+1. **resolutionOrder** is traversed
+1. **#/sets/foundation** is parsed, and the tokens `foundation/colors.tokens.json` and `foundation/layout.tokens.json` are merged in that order.
+1. **#/modifiers/theme** is parsed, which contains a “fork” for either light or dark theme, depending on the user’s input.
+
+How you provide that “input” for the modifier depends on the tool. In Terrazzo’s case, that’s usually passed into [plugin options](/docs/integrations/). For example, for the [CSS plugin](/docs/integrations/css/):
+
+:::code-group
+
+```ts [terrazzo.config.ts]
+import css from "@terrazzo/plugin-css";
+
+export default {
+  plugins: [
+    css({
+      contextSelectors: [
+        { selector: ":root", context: { theme: "light" } },
+        {
+          selector: "@media (prefers-color-scheme: dark)",
+          context: { theme: "dark" },
+        },
+      ],
+    }),
+  ],
+};
+```
+
+:::
+
+This would then apply the light theme by default (`:root`), and then the dark theme if the user’s system was in dark mode.
+
+:::tip
+
+The context was called `theme` because our modifier lived at `#/modifiers/theme`. We could have named our modifier anything we want. You can also have as many additional modifiers you want (as long as 2 modifiers don’t share the same name).
+
+:::
+
+Inputs will differ by plugin, because the code will differ! How you map contexts to each code output could vary wildly, so be sure to read the documentation for each plugin you’re using.
+
+### Playground
+
+To see more examples of how resolvers can work, [**play around with Resolvers in the Playground**](https://dtcg-resolver-playground.pages.dev)!
+
+## Modes (legacy)
+
+Legacy modes are still supported, if you were using Cobalt 1.0 or Terrazzo beta. In your tokens, you can keep `$extensions.mode`. But just map each context to a special `tzMode` namespace. In this way, you can use both old and new syntax together, without conflicts!
+
+Here’s an example how the options would change for the CSS plugin:
+
+:::code-group
+
+```diff [terrazzo.config.ts]
+  import css from "@terrazzo/plugin-css";
+
+  export default {
+    plugins: [
+      css({
+-       modeSelectors: [
+-         { selector: ":root", mode: "light" },
+-         { selector: "@media (prefers-color-scheme: dark)", mode: "dark" },
++       contextSelectors: [
++         { selector: ":root", context: { tzMode: "light" } },
++         { selector: "@media (prefers-color-scheme: dark)", context: { tzMode: "dark" } },
+        ],
+      }),
+    ],
+  };
+```
+
+:::
+
+Note that even if we’re not using the new resolver syntax, Terrazzo will simply pretend like we had a secret modifier called `tzMode`.

--- a/www/src/pages/docs/2.0/guides/resolvers.md
+++ b/www/src/pages/docs/2.0/guides/resolvers.md
@@ -1,0 +1,186 @@
+---
+title: Resolvers
+layout: ../../../../layouts/docs.astro
+---
+
+## Resolvers
+
+A [resolver](https://www.designtokens.org/tr/2025.10/resolver) is a meta-file that describes how collections of DTCG tokens relate to one another. In its simplest form, a resolver can flatten multiple tokens JSON files into one. But most of the time resolvers are used to provide contextual token values, such as light/dark mode, color themes, or other complex usecases.
+
+Resolvers are a DTCG standard, and the successor to legacy [modes](/docs/guides/modes) that are only understood by Terrazzo/Cobalt.
+
+## Writing a resolver
+
+You can think of a resolver as an “entry” file to your tokens, similar to an entry file to a bundler like webpack or Rollup. A resolver describes how all of your tokens should be collated, or _resolved_, into a final set.
+
+### Name, version, and description
+
+The first step is naming your resolver and declaring the `version` of the specification. There’s only one valid version: `2025.10`. This is reserved for future versions.
+
+You may also optionally declare a `description` to add additional detail, but it’s not necessary.
+
+:::code-group
+
+```json [my-ds.resolver.json]
+{
+  "name": "My DS",
+  "description": "v2.1 of the design system",
+  "version": "2025.10"
+}
+```
+
+:::
+
+### Sets
+
+A set is any arbitrary group of tokens that are meaningful to you. To some folks they may want to separate [primitive, semantic, and component tokens](https://thedesignsystem.guide/design-tokens) into different sets. For others, they may want to separate different categories of tokens such as colors, typography, and spacing tokens into individual sets. There’s no wrong answer! In many cases, you’ll just start off with a single set, and break it out when it grows too large.
+
+You declare a set by making an entry in the `sets` object, and pointing to the JSON files it comprises:
+
+:::code-group
+
+```jsonc [my-ds.resolver.json]
+{
+  "name": "My DS",
+  "version": "2025.10",
+  "sets": {
+    "colors": {
+      "description": "Color ramps and gradients",
+      "sources": [
+        { "$ref": "colors/ramps.tokens.json" },
+        { "$ref": "colors/semantic.tokens.json" },
+      ],
+    },
+    "typography": {
+      "sources": [{ "$ref": "typography/fonts.tokens.json" }],
+    },
+    "sizing": {
+      "description": "Margin, padding, and layout values",
+      "sources": [
+        { "$ref": "sizing/layout.tokens.json" },
+        { "$ref": "sizing/breakpoints.tokens.json" },
+        { "$ref": "sizing/padding.tokens.json" },
+      ],
+    },
+  },
+}
+```
+
+:::
+
+In this example, we have 3 sets:
+
+1. `colors`
+1. `typography`
+1. `sizing`
+
+The order within the `sets` object does NOT matter—we’ll determine a final ordering within [resolutionOrder](#resolutionOrder). But the order within `sources` _DOES_. In case of a conflict, the occurrence of a token last in the array takes precedence.
+
+For every set you may also optionally add a `description` but this isn’t required.
+
+:::tip
+
+`$ref` can be used to point anywhere! This can point to a remote file, _part_ of a remote file, another URL, or even a point in the same document. [Learn more](https://www.designtokens.org/tr/2025.10/resolver/#reference-objects).
+
+:::
+
+### Modifiers
+
+Modifiers, like sets, group tokens into meaningful groups. But they also allow for conditional values, where tokens resolve to different values in different contexts.
+
+Each modifier has a `contexts` map that maps a condition to the tokens that get applied as a result.
+
+:::code-group
+
+```jsonc [my-ds.resolver.json]
+{
+  "name": "My DS",
+  "version": "2025.10",
+  "sets": {
+    // …
+  },
+  "modifiers": {
+    "theme": {
+      "description": "Color theme",
+      "contexts": {
+        "light": [],
+        "dark": [{ "$ref": "./theme/dark.json" }],
+        "light-high-contrast": [{ "$ref": "./theme/light-hc.json" }],
+        "dark-high-contrast": [{ "$ref": "./theme/dark-hc.json" }]
+      }
+    },
+    "breakpoint": {
+      "description": "Responsive size",
+      "contexts": {
+        "sm": [
+          { "$ref": "./breakpoint/sm.json" },
+          { "$ref": "./typography/sm.json" }
+        ]
+        "md": [],
+        "lg": [
+          { "$ref": "./breakpoint/lg.json" },
+          { "$ref": "./typography/lg.json" }
+        ],
+      },
+      "default": "md"
+    }
+  }
+}
+```
+
+:::
+
+In this example, we have 2 modifiers:
+
+1. `theme`: has `light`, `dark`, `light-high-contrast`, and `dark-high-contrast` contexts.
+1. `breakpoint`: has `sm`, `md` (default), and `lg` contexts.
+
+For each modifier, **only 1 context can be activated at any time.** A consumer of this must specify one value for every modifier declared (unless that modifier declares a `default` context, which is optional; in our example, `breakpoint` declares `md` to be the default).
+
+### resolutionOrder
+
+The final piece of the puzzle is the resolution order. This is the top-level ordering of the final result, and declares which order the sets and modifiers get combined in.
+
+:::code-group
+
+```jsonc [my-ds.resolver.json]
+{
+  "name": "My DS",
+  "version": "2025.10",
+  "sets": {
+    // …
+  },
+  "modifiers": {
+    // …
+  },
+  "resolutionOrder": [
+    { "$ref": "#/sets/colors" },
+    { "$ref": "#/sets/sizing" },
+    { "$ref": "#/sets/typography" },
+    { "$ref": "#/modifiers/breakpoint" },
+    { "$ref": "#/modifiers/theme" },
+  ],
+}
+```
+
+:::
+
+Note that the order that sets and modifiers were originally declared in is arbitrary; this is the ordering that actually matters in the end. The order ultimately affects overrides, where in case of conflict, items later in the array will override any tokens that came before them.
+
+Another way to look at this is `#/sets/[name]` and `#/modifiers/[name]` are the “dictionaries” to pull from, and `resolutionOrder` is the merge order of those dictionaries into one final result.
+
+:::tip
+
+Most of the time, modifiers come after sets, because conditional values almost always mean to override unconditional ones. Some systems may have some exceptions, of course, but in most systems, modifiers come at the end, and sets at the beginning.
+
+:::
+
+## FAQ
+
+### Do I have to have my tokens in multiple files?
+
+No! You can actually have one `.resolver.json` file that declares all of your tokens, sets, and modifiers with no external references. See the [bundling guide](https://www.designtokens.org/tr/2025.10/resolver/#bundling) in the specification for more info.
+
+### Is a resolver required now?
+
+No. But a resolver is required whenever you have contextual values such as themes or color modes.

--- a/www/src/pages/docs/2.0/guides/styleguide.md
+++ b/www/src/pages/docs/2.0/guides/styleguide.md
@@ -1,0 +1,85 @@
+---
+title: DS Styleguide
+layout: ../../../../layouts/docs.astro
+---
+
+# DS Styleguide
+
+Creating a design system from scratch is hard! And it’s really tough to make changes once people start consuming a design system, because by its nature it’s meant to proliferate quickly (and becomes deeply-embedded quickly).
+
+The following are rough tips and tricks to organizing and naming design tokens that work well for most setups, compiled partially from experience and partially from borrowing the best of other public design systems.
+
+## Color
+
+Color tokens make up not only the largest volume of most design tokens; they also tend to be the most complex systems (and the largest source of accessibility errors through failing contrast). Thus, getting color right is the biggest payoff for any system. Here are some general tips to
+
+### No component tokens
+
+An emerging pattern in design token naming is layering **Primitive** → **Semantic** → **Component** tokens ([example](https://thedesignsystem.guide/design-tokens)).
+
+| Layer     | Description                                                                                   |
+| :-------- | :-------------------------------------------------------------------------------------------- |
+| Primitive | The lowest layer. Descriptive. Consists of raw values (e.g. `color.gray.200`).                |
+| Semantic  | 2nd layer. Consists of **Meaning** and **usage** (e.g. `color.success`).                      |
+| Component | 3rd layer. Maps tokens from previous layers to component properties (e.g. `button.bg-color`). |
+
+All layers will use [modes](/docs/guides/modes). And for that reason, every additional layer of tokens exponentially increases the possible number of tokens you’ll have to manage. But by the time you’ve reached the component layer, you’ve already reached an order of magnitude that is unsustainable for most teams (Atlassian quoted their number of tokens at 37,000 due to component tokens [source from Config 2024; talk upload pending]!). And for that reason, limiting your tokens to **2 layers: primitive and semantic** will yield dividends in saved time and complexity.
+
+:::warning
+
+TL;DR **don’t use component tokens.** Instead, try and find common threads of intent to drastically deduplicate the number of tokens you’ll have to manage.
+
+:::
+
+### Don’t invert colors in primitive layer
+
+A common pitfall of building [color ramps](https://ferdychristant.com/color-for-the-color-challenged-884c7aa04a56) is trying to handle light and dark mode at the lowest layer by inverting it there. Take for example Radix colors:
+
+<figure>
+  <img src="/assets/radix-colors.png" aria-hidden />
+  <figcaption>Radix colors is a great system, but inverting primitive colors like this can lead to unnecessary complexity.</figcaption>
+</figure>
+
+Most flawed dark mode approaches start with an innocent pitch: “let’s just invert the color ramp and see how far we get!.” The answer is: _not very far_. **Every design system needs to invert at the semantic layer.**
+
+#### Example
+
+For an example, let’s work out colors for “elevated” components: Dialogs, Tooltips, Dialogs, etc. Starting from basic color theory—cool/dark colors recede; warm/light colors come forward—we want elevated UI to be lighter than the background (either flatly, with a dropshadow, or both). So we map `color.bg` to the **darkest gray**, and the elevated components are 1 step lighter:
+
+| Component Property  | Dark Mode                         |
+| :------------------ | --------------------------------- |
+| Main background     | `color.gray.100` (darkest)        |
+| Elevated background | `color.gray.200` (1 step lighter) |
+
+<figure>
+  <img src="/assets/tooltip-dialog-light-dark-mode.png" aria-hidden />
+  <figcaption>“Elevated” components like tooltips, dialogs, and popovers are usually the points where naïve light/dark mode implementations break.</figcaption>
+</figure>
+
+So far so good, but we have a problem when we go to light mode. If we simply invert the colors, we end up with **elevated UI being darker than the background** (middle illustration), which is not what we want. It seems like it’s disabled!
+
+| Component Property  | Dark Mode        | Light Mode                     |
+| :------------------ | :--------------- | :----------------------------- |
+| Main background     | `color.gray.100` | `color.gray.100`               |
+| Elevated background | `color.gray.200` | ❌ `color.gray.200` (too dark) |
+
+And so to fix it, we end up with this awkward remapping here:
+
+| Component Property  | Dark Mode        | Light Mode          |
+| :------------------ | :--------------- | :------------------ |
+| Main background     | `color.gray.100` | `color.gray.200`    |
+| Elevated background | `color.gray.200` | ✅ `color.gray.100` |
+
+Already our plan to invert the primitive token ramp backfired: we already had to decouple the colors at the semantic layer for elevated UI. So it begs the question: **if the colors have to be remapped at the semantic layer anyway, does inverting the scale just add to confusion?** For most systems, the answer is “yes”—inverting just adds unnecessary confusion. Compare:
+
+| Universal direction              | Inverted direction               |
+| :------------------------------- | :------------------------------- |
+| `100` is always “lightest” value | `100` is… hang on… let me think… |
+
+Whether `100` is “lightest” or “darkest” doesn’t matter (or whatever number system you use, for that matter). The choice is yours. The only callout here is to **make it consistent across all modes** so working across modes is easier.
+
+:::tip
+
+TL;DR — always ramping your colors in a universal direction for both light and dark mode saves unnecessary headaches.
+
+:::

--- a/www/src/pages/docs/2.0/integrations/css-in-js.md
+++ b/www/src/pages/docs/2.0/integrations/css-in-js.md
@@ -1,0 +1,82 @@
+---
+title: CSS-in-JS
+layout: ../../../../layouts/docs.astro
+---
+
+# CSS-in-JS
+
+Reference CSS variables from [plugin-css](https://github.com/terrazzoapp/terrazzo/blob/main/packcages) in JS. Compatible with Linaria, StyleX, Vanilla Extract, Styled Components, and most CSS-in-JS libraries.
+
+## Setup
+
+Requires [Node.js](https://nodejs.org). With that installed, run:
+
+```sh
+npm i -D @terrazzo/cli @terrazzo/plugin-css @terrazzo/plugin-css-in-js
+```
+
+Add a `terrazzo.config.ts` to the root of your project with:
+
+```ts
+import { defineConfig } from "@terrazzo/cli";
+import css from "@terrazzo/plugin-css";
+import cssInJs from "@terrazzo/plugin-css-in-js";
+
+export default defineConfig({
+  outDir: "./tokens/",
+  plugins: [
+    css(),
+    cssInJs({
+      filename: "vars.js", // Note: `.d.ts` is generated too
+    }),
+  ],
+});
+```
+
+Lastly, run:
+
+```sh
+npx tz build
+```
+
+And you’ll see a `./tokens/vars.js` file generated in your project.
+
+## Usage
+
+Your tokens will be exported with each root-level group being its own export. It will export a type-safe, nested object that matches your token names. The CSS vars will correctly mirror all outputs from [plugin-css](/docs/integrations/css).
+
+:::code-group
+
+```tsx
+import stylex from "@stylexjs/stylex";
+import { color } from "./tokens/vars.js";
+
+const styles = stylex.create({
+  button: {
+    background: color.bg.brand, // var(--color-bg-brand)
+    color: color.text.onBrand, // var(--color-text-on-brand)
+  },
+});
+```
+
+:::
+
+Alternately, you can import all vars using a glob import:
+
+```ts
+import * as myDS from "./tokens/vars.js";
+```
+
+Note that for numeric or invalid properties, you’ll have to use bracket syntax, like so:
+
+```ts
+const styles = stylex.create({
+  button: {
+    padding: space["100"], // var(--space-100)
+  },
+});
+```
+
+## Comparison to plugin-vanilla-extract
+
+Terrazzo also ships [plugin-vanilla-extract](/docs/integrations/vanilla-extract) for a slightly-deeper integration with its [theme API](https://vanilla-extract.style/documentation/theming/). plugin-css-in-js by comparison is a generic approach that has no awareness of any specific library API, but this will work with Vanilla Extract just as well if you don’t need the deeper features.

--- a/www/src/pages/docs/2.0/integrations/sass.md
+++ b/www/src/pages/docs/2.0/integrations/sass.md
@@ -1,0 +1,93 @@
+---
+title: Sass
+layout: ../../../../layouts/docs.astro
+---
+
+# Sass
+
+Convert DTCG tokens into Sass for use in any web application or native app with webview. Uses [the CSS plugin](/docs/integrations/css) under the hood that lets you use all of CSS’ features with the typesafety of Sass.
+
+## Setup
+
+Requires [Node.js](https://nodejs.org) and [the CLI installed](/docs). With both installed, run:
+
+:::npm
+
+```sh
+npm i -D @terrazzo/plugin-css @terrazzo/plugin-sass
+```
+
+:::
+
+And add both to your `terrazzo.config.js` under `plugins` (order doesn’t matter):
+
+:::code-group
+
+```js [terrazzo.config.js]
+import { defineConfig } from "@terrazzo/cli";
+import css from "@terrazzo/plugin-css";
+import sass from "@terrazzo/plugin-sass";
+
+export default defineConfig({
+  plugins: [
+    css({
+      filename: "tokens.css",
+      modeSelectors: [
+        { mode: "light", selectors: ["@media (prefers-color-scheme: light)"] },
+        { mode: "dark", selectors: ["@media (prefers-color-scheme: dark)"] },
+      ],
+    }),
+    sass({
+      filename: "index.scss",
+    }),
+  ],
+});
+```
+
+:::
+
+Then when running `tz build`, you’ll see the following files generated in your `tokens/` output dir (or however you named them):
+
+- `index.scss`
+- `tokens.css`
+
+Be sure to **load both files in your project!** Otherwise you’ll have missing values.
+
+## Config
+
+:::code-group
+
+```ts [terrazzo.config.js]
+import { defineConfig } from "@terrazzo/cli";
+import css from "@terrazzo/plugin-css";
+import sass from "@terrazzo/plugin-sass";
+
+export default defineConfg({
+  plugins: [
+    css(),
+    sass({
+      filename: "index.scss",
+      exclude: [],
+    }),
+  ],
+});
+```
+
+:::
+
+| Name       | Type       | Description                                            |
+| :--------- | :--------- | :----------------------------------------------------- |
+| `filename` | `string`   | Rename the output `.scss` file (default: `index.scss`) |
+| `exclude`  | `string[]` | (optional) Glob pattern(s) of token IDs to exclude.    |
+
+## Migrating from Cobalt 1.x
+
+The original Cobalt 1.x Sass plugin allowed you to use it in “hardcoded mode” or “CSS variable mode.” The hardcoded mode was limiting because it lacked all the dynamism that CSS allows with variables and media queries. And as the default behavior, it seemed to encourage an increasingly less-ideal output.
+
+The CSS variable mode was much better by comparison, but the limiting 1.x plugin API resulted in some hacky workarounds that were ultimately unwieldy and buggy, especially with modes.
+
+In the latest version, the CSS plugin has been improved and enhanced even further (it’s arguably the most mature out of all plugins), and takes advantage of the rapid development of CSS over the past few years. Since Sass ultimately _must_ compile to CSS anyway, it just made sense to encourage users to take advantage of the CSS plugin’s power, and make the Sass plugin a thin typechecking layer on top of that. This should result in more features and flexibility, and smoother interop between the two.
+
+The less-popular `.sass` output mode was also removed just to reduce maintenance, but it can be added back for the one person that still uses that syntax 😉.
+
+All that said, you’ll find (intentionally) fewer options in this Sass plugin, for an improved experience.

--- a/www/src/pages/docs/2.0/integrations/swift.md
+++ b/www/src/pages/docs/2.0/integrations/swift.md
@@ -1,0 +1,40 @@
+---
+title: Swift
+layout: ../../../../layouts/docs.astro
+---
+
+# Swift
+
+Generate Swift asset catalogs from DTCG tokens.
+
+## Setup
+
+Requires [Node.js](https://nodejs.org). With that installed, and a `package.json`, run:
+
+```sh
+npm i -D @terrazzo/cli @terrazzo/plugin-swift
+```
+
+Add a `terrazzo.config.js` to the root of your project with:
+
+```ts
+import { defineConfig } from "@terrazzo/cli";
+import swift from "@terrazzo/plugin-swift";
+
+export default defineConfig({
+  outDir: "./tokens/",
+  plugins: [
+    swift({
+      catalogName: "Tokens",
+    }),
+  ],
+});
+```
+
+Lastly, run:
+
+```sh
+npx tz build
+```
+
+And you’ll see a `./tokens/Tokens.xcassets` catalog generated in your project. [Import it](https://developer.apple.com/documentation/xcode/managing-assets-with-asset-catalogs) into your project and you’ll have access to all your tokens!

--- a/www/src/pages/docs/2.0/integrations/tailwind.md
+++ b/www/src/pages/docs/2.0/integrations/tailwind.md
@@ -1,0 +1,198 @@
+---
+title: Tailwind
+layout: ../../../../layouts/docs.astro
+---
+
+# Tailwind
+
+The Tailwind Terrazzo plugin can generate a [Tailwind v4 Theme](https://tailwindcss.com/docs/theme#theme) from your design tokens. This lets you use the power of Tailwind with DTCG tokens!
+
+## Setup
+
+Requires [Node.js](https://nodejs.org) and [the CLI installed](/docs). With both installed, run:
+
+:::npm
+
+```sh
+npm i -D @terrazzo/cli @terrazzo/plugin-tailwind
+```
+
+:::
+
+And add it to `terrazzo.config.js` under `plugins`:
+
+:::code-group
+
+```js [terrazzo.config.js]
+import { defineConfig } from "@terrazzo/cli";
+import css from "@terrazzo/plugin-css";
+import tailwind from "@terrazzo/plugin-tailwind";
+
+export default defineConfig({
+  outDir: "./tokens/",
+  plugins: [
+    css(),
+    tailwind({
+      filename: "tailwind.js",
+
+      theme: {
+        /** @see https://tailwindcss.com/docs/configuration#theme */
+        color: ["color.*"],
+        font: {
+          sans: "typography.family.base",
+        },
+        spacing: ["spacing.*"],
+        radius: ["borderRadius.*"],
+      },
+    }),
+  ],
+});
+```
+
+:::
+
+Lastly, run:
+
+```sh
+npx tz build
+```
+
+And you’ll see a `tokens/tailwind-theme.css` file generated in your project.
+
+## Options
+
+| Name           | Type                                  | Description                                             |
+| :------------- | :------------------------------------ | :------------------------------------------------------ |
+| `filename`     | `string`                              | Filename to generate (default: `"tailwind-theme.css"`). |
+| `theme`        | `Record<string, any>`                 | Tailwind theme ([docs](#theme))                         |
+| `modeVariants` | `{ variant: string, mode: string }[]` | See [Dark mode & variants](#dark-mode-&-variants).      |
+
+## Theme
+
+Tailwind has [theme docs](https://tailwindcss.com/docs/theme) that map CSS variables to Tailwind classes. This plugin generates that CSS for you, but you still have to provide the desired mapping here.
+
+### Token mapping
+
+Let’s take a look at a common case: **color**. In Tailwind, those are handled via `--color-*` tokens. Let’s say we have tokens `--color-blue-0` … `color-blue-9` and we want to add those to Tailwind. We could do any of the above:
+
+We can declare
+
+```js
+tailwind({
+  theme: {
+    color: {
+      blue: {
+        0: "color.blue.0",
+        1: "color.blue.1",
+        // …
+        9: "color.blue.9",
+      },
+    },
+  },
+});
+```
+
+That will generate:
+
+```css
+@theme {
+  --color-blue-0: #ddf4ff;
+  --color-blue-1: #b6e3ff;
+  /* … */
+  --color-blue-9: #002155;
+}
+```
+
+#### Arrays
+
+Being explicit is fine! And it’s needed when you need to rename or remap complex things. But whenever you’re declaring tokens 1:1, you can save some typing:
+
+```js
+tailwind({
+  theme: {
+    color: {
+      blue: ["color.blue.*"],
+    },
+  },
+});
+```
+
+Or even more tersely:
+
+```js
+tailwind({
+  theme: {
+    color: ["color.*"],
+  },
+});
+```
+
+Which will generate the same CSS. Terrazzo simply expanded the keys & values into an object for you.
+
+Globs are powered by [picomatch](https://www.npmjs.com/package/picomatch), so you could do advanced filters like `['color.{red,blue}.*']`. [See the picomatch docs](https://www.npmjs.com/package/picomatch) for supported syntax.
+
+#### Gotchas
+
+Note that things will be named starting from the `*`, so if you had, say,
+
+```js
+tailwind({
+  theme: {
+    color: { blue: ["color.*"] },
+  },
+});
+```
+
+Then that would unpack to `--color-blue-blue-0`, `--color-blue-blue-1`, etc. Further, if you tried to unpack conflicting token names, e.g.:
+
+```js
+tailwind({
+  theme: {
+    color: ["color.blue.*", "color.blue.red.*"],
+  },
+});
+```
+
+You’d wind up with `--color-0`, `--color-1`, etc. which would point to `color.red.*` since it came last in the array.
+
+All that said, keep in mind that **theme mapping is up to you!** So the theme will be built exactly as you’ve declared.
+
+### Dark mode & variants
+
+Tailwind considers dark mode as a [variant](https://tailwindcss.com/docs/functions-and-directives#variant-directive) underneath, which means you’re not restricted to simply dark mode when using modes in tokens.
+
+By declaring a `variants` array with both `selector` (Tailwind) and `mode` (DTCG mode), you can generate the following CSS:
+
+```diff
+  tailwind({
+    theme: {
+      color: ["color.*"],
+    },
++   modeVariants: [
++     { variant: "dark", mode: "dark" },
++     { variant: "hc", mode: "high-contrast" },
++   ],
+  });
+```
+
+Produces:
+
+```css
+@theme {
+  /* base tokens */
+}
+
+@variant dark {
+  /* mode: dark tokens */
+}
+
+@variant hc {
+  /* mode: hc tokens */
+}
+```
+
+:::note
+
+As of 2.0, since plugin-css no longer computes all permutations of tokens automatically (due to DTCG Resolvers, some design systems have thousands of permutations that are a waste of time to build), you’ll need to add `modeSelectors` for the variants you want to generate.
+
+:::

--- a/www/src/pages/docs/2.0/integrations/vanilla-extract.md
+++ b/www/src/pages/docs/2.0/integrations/vanilla-extract.md
@@ -1,0 +1,129 @@
+---
+title: Vanilla Extract
+layout: ../../../../layouts/docs.astro
+---
+
+# Vanilla Extract
+
+Generate [Vanilla Extract](https://vanilla-extract.style) themes from DTCG tokens.
+
+## Setup
+
+Requires [Node.js](https://nodejs.org). With that installed, run:
+
+:::npm
+
+```sh
+npm i -D @terrazzo/cli @terrazzo/plugin-css @terrazzo/plugin-vanilla-extract
+```
+
+:::
+
+Add a `terrazzo.config.ts` to the root of your project with:
+
+:::code-group
+
+```ts [terrazzo.config.ts]
+import { defineConfig } from "@terrazzo/cli";
+import css from "@terrazzo/plugin-css";
+import vanillaExtract from "@terrazzo/plugin-vanilla-extract";
+
+export default defineConfig({
+  plugins: [
+    css({
+      // Optional: control the final CSS variable names
+      variableName: (token) => token.id.replace(/\./g, "-"),
+      // Optional: pass `skipBuild: true` to not generate a .css file if only using Vanilla Extract.
+      skipBuild: false,
+    }),
+
+    vanillaExtract({
+      filename: "themes.css.ts",
+      // Use global CSS vars (recommended). Your Vanilla Extract CSS is still scoped.
+      globalThemeContract: true,
+
+      // Option 1: scoped themes
+      themes: {
+        light: { mode: [".", "light"] },
+        dark: { mode: [".", "dark"] },
+      },
+
+      // Option 2: global themes (in case you have code outside Vanilla Extract)
+      globalThemes: {
+        globalLight: { selector: "[data-color-mode=light]", mode: [".", "light"] },
+        globalDark: { selector: "[data-color-mode=dark]", mode: [".", "dark"] },
+      ],
+    }),
+  ],
+});
+```
+
+## Resolvers (new)
+
+To use resolvers in this plugin, you MUST specify your `permutations` in plugin-css, and use `input` instead, like so:
+
+:::code-group
+
+```ts [terrazzo.config.ts]
+import { defineConfig } from "@terrazzo/cli";
+import css from "@terrazzo/plugin-css";
+import vanillaExtract from "@terrazzo/plugin-vanilla-extract";
+
+const light = { theme: 'light' }
+const dark = { theme: 'dark' }
+
+export default defineConfig({
+  plugins: [
+    css({
+      permutations: [
+        { ...light, prepare: (css) => `:root {\n  color-scheme: light dark;\n  ${css}\n}` },
+        { ...dark, prepare: (css) => `@media (prefers-color-scheme: dark) {\n  :root {\n    color-scheme: dark;\n    ${css}\n  }\n}` },
+      ],
+    }),
+
+    vanillaExtract({
+      globalThemeContract: true,
+      globalThemes: {
+        globalLight: { selector: "[data-color-mode=light]", input: light },
+        globalDark: { selector: "[data-color-mode=dark]", input: dark },
+      ],
+    }),
+  ],
+});
+```
+
+:::
+
+Specifying permutations is required because in the world of resolvers, there are too many possible combinations that may not match up, so plugin-css won’t generate those variables unless you ask for them.
+
+## Options
+
+| Name                | Type                                                                 | Default                 | Description                                                                                                                                                                         |
+| :------------------ | :------------------------------------------------------------------- | :---------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| filename            | `string`                                                             | `theme.css.ts`          | The filename to generate.                                                                                                                                                           |
+| globalThemeContract | `boolean`                                                            | `true`                  | If `false`, it will generate a scoped [createThemeContract()](https://vanilla-extract.style/documentation/api/create-theme-contract/) instead.                                      |
+| themes              | `{ [name: string]: { mode: string \| string[] }`                     |                         | Generate one [createTheme()](https://vanilla-extract.style/documentation/api/create-theme/) per object key. The key is the variable name that will be exported.                     |
+| globalThemes        | `{ [name: string]: { mode: string \| string[], selector: string } }` |                         | Generate one [createGlobalTheme()](https://vanilla-extract.style/documentation/global-api/create-global-theme/) per object key. The key is the variable name that will be exported. |
+| themeVarNaming      | `(name: string) => [class, vars]`                                    | `[{name}Class, {name}]` | Change the naming strategy for the [createTheme()](https://vanilla-extract.style/documentation/api/create-theme/) API’s `[class, vars]` tuple.                                      |
+
+## Interop with plugin-css
+
+This plugin is a thin wrapper around [plugin-css](/docs/integrations/css/), which ensures the output is valid CSS. But since Vanilla Extract is an extension, only some settings matter:
+
+| Option          | Applies to Vanilla Extract                                                                        |
+| :-------------- | :------------------------------------------------------------------------------------------------ |
+| `permutations`  | **Yes** If using resolvers, these are required!                                                   |
+| `variableName`  | **Yes** (if `globalThemeContract: true`)                                                          |
+| `exclude`       | **Yes**                                                                                           |
+| `skipBuild`     | **Yes**                                                                                           |
+| `legacyHex`     | **Yes**                                                                                           |
+| `transform`     | **Yes** (if used)                                                                                 |
+| `modeSelectors` | **No**                                                                                            |
+| `utility`       | **No** (use [Sprinkles](https://vanilla-extract.style/documentation/packages/sprinkles/) instead) |
+| `baseSelector`  | **No** (overridden by Vanilla Extract themes)                                                     |
+
+:::warning
+
+Though in most scenarios plugin-css agrees with Vanilla Extract (because Terrazzo manages both), some usages of `modeSelectors` could potentially conflict. If that happens, you may want to set `globalThemeContract: false` in Vanilla Extract.
+
+:::

--- a/www/src/styles/docs.css
+++ b/www/src/styles/docs.css
@@ -53,7 +53,10 @@
 
     &:first-child {
       margin-block-start: 0;
-      padding-block-start: var(--tz-space-600);
+
+      @media (width > 750px) {
+        padding-block-start: var(--tz-space-600);
+      }
     }
   }
 


### PR DESCRIPTION
## Changes

Adds 2.0 version switcher, to prepare for the upcoming release.

<img width="2842" height="920" alt="CleanShot 2026-02-04 at 12 11 01@2x" src="https://github.com/user-attachments/assets/df685a83-1f0a-4739-a097-d2c0015f9b98" />


<img width="2808" height="784" alt="CleanShot 2026-02-04 at 12 10 52@2x" src="https://github.com/user-attachments/assets/116d44de-5563-4a60-8862-9eff25a72a9d" />

Duplicates a lot of docs, which is OK because we‘ll need to freeze the 0.x docs at `/docs/0.x` so this just prepares for that.

## How to Review

- Docs-only change
