### PR TITLE
Feat: add back Figma import (1/2)

### DIFF
--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,3 +1,4 @@
 test/fixtures/**/tokens/
 test/fixtures/init/terrazzo.config.js
 test/fixtures/**/actual.json
+test/fixtures/import-figma/*.actual.json

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 2.0.0
 
+The 2.0.0 release is full of new features:
+
+- Full support for the DTCG v2025.10 spec, including resolvers
+- New and improved [native Figma import](https://terrazzo.app/docs/guides/import-from-figma)
+- `@terrazzo/plugin-js` was reimagined as a resolver API to build your own token machine (server-side)
+- `@terrazzo/plugin-css-in-js` was added as the missing solution for type-safe JS to use in any CSS-in-JS library
+- And of course dozens of bugfixes and quality of life improvements
+
 ### Minor Changes
 
 - [#530](https://github.com/terrazzoapp/terrazzo/pull/530) [`370ed7b`](https://github.com/terrazzoapp/terrazzo/commit/370ed7b0f578a64824124145d7f4936536b37bb3) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ Breaking change; DTCG 2nd Editors draft format will throw errors by default. This means converting all colors and dimensions to the new object format.
@@ -48,7 +56,7 @@
   - Typography
 
   These behaviors may be opted out individually by adjusting the new lint rules ([see documentation](https://terrazzo.app/cli/linting/)).
-  
+
 - [#589](https://github.com/terrazzoapp/terrazzo/pull/589) [`8f32d44`](https://github.com/terrazzoapp/terrazzo/commit/8f32d44792bba62194e674c9b60cfdeb366c96c7) Thanks [@michaelurban](https://github.com/michaelurban)! - feat: add typography shorthand, improve Sass plugin
 
 ### Patch Changes

--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -29,7 +29,17 @@ import { createRequire } from 'node:module';
 import { parseArgs } from 'node:util';
 import { Logger } from '@terrazzo/parser';
 import dotenv from 'dotenv';
-import { buildCmd, checkCmd, helpCmd, initCmd, labCmd, loadConfig, normalizeCmd, versionCmd } from '../dist/index.js';
+import {
+  buildCmd,
+  checkCmd,
+  helpCmd,
+  importCmd,
+  initCmd,
+  labCmd,
+  loadConfig,
+  normalizeCmd,
+  versionCmd,
+} from '../dist/index.js';
 
 const require = createRequire(process.cwd());
 
@@ -44,11 +54,13 @@ const { values: flags, positionals } = parseArgs({
   allowPositionals: true,
   options: {
     config: { type: 'string', short: 'c' },
-    out: { type: 'string', short: 'o' },
-    output: { type: 'string' },
+    output: { type: 'string', short: 'o' },
     help: { type: 'boolean' },
     silent: { type: 'boolean' },
+    'skip-styles': { type: 'boolean' },
+    'skip-variables': { type: 'boolean' },
     quiet: { type: 'boolean' }, // secret alias for --silent because I can’t remember it
+    unpublished: { type: 'boolean' },
     watch: { type: 'boolean', short: 'w' },
     version: { type: 'boolean' },
   },
@@ -96,7 +108,12 @@ export default async function main() {
 
   // normalize
   if (cmd === 'normalize') {
-    await normalizeCmd(positionals[1], { logger, output: flags.out ?? flags.output });
+    await normalizeCmd(positionals[1], { logger, output: flags.output });
+    process.exit(0);
+  }
+  // import
+  if (cmd === 'import') {
+    await importCmd({ flags, logger, positionals });
     process.exit(0);
   }
 
@@ -118,6 +135,7 @@ export default async function main() {
       await initCmd({ config, flags, logger });
       break;
     }
+
     case 'lab': {
       try {
         require.resolve('@terrazzo/token-lab');

--- a/packages/cli/biome.json
+++ b/packages/cli/biome.json
@@ -5,13 +5,6 @@
   "files": {
     "includes": ["bin/**", "src/**", "test/**/*.test.ts", "**/*.tsx"]
   },
-  "linter": {
-    "rules": {
-      "suspicious": {
-        "noConsole": "off"
-      }
-    }
-  },
   "overrides": [
     {
       "includes": ["./bin/cli.js"],

--- a/packages/cli/lab.tsx
+++ b/packages/cli/lab.tsx
@@ -18,6 +18,7 @@ root.render(
       });
 
       if (!response.ok) {
+        // biome-ignore lint/suspicious/noConsole: this is its job
         console.error(`Failed to save tokens: ${response.status}`);
       }
     }}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,6 +66,7 @@
     "yaml-to-momoa": "catalog:"
   },
   "devDependencies": {
+    "@figma/rest-api-spec": "^0.36.0",
     "@swc/core": "catalog:",
     "@swc/core-darwin-arm64": "catalog:",
     "@swc/core-darwin-x64": "catalog:",

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -75,6 +75,7 @@ export async function buildCmd({ config, configPath, flags, logger }: BuildOptio
           }
           writeFiles(result, { config, logger });
         } catch (err) {
+          // biome-ignore lint/suspicious/noConsole: this is its job
           console.error(pc.red(`✗  ${(err as Error).message || (err as string)}`));
           // don’t exit! we’re watching, so continue as long as possible
         }

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -1,18 +1,25 @@
 /** Show help */
 export function helpCmd() {
+  // biome-ignore lint/suspicious/noConsole: this is its job
   console.log(`tz
   [commands]
-    build           Build token artifacts from tokens.json
-      --watch, -w   Watch tokens.json for changes and recompile
-      --no-lint     Disable linters running on build
-    check [path]    Check tokens.json for errors and run linters
-    lint [path]     (alias of check)
-    init            Create a starter tokens.json file
-    lab             Manage your tokens with a web interface
+    build            Build token artifacts from tokens.json
+      --watch, -w    Watch tokens.json for changes and recompile
+      --no-lint      Disable linters running on build
+    check [path]     Check tokens.json for errors and run linters
+    lint [path]      (alias of check)
+    init             Create a starter tokens.json file
+    lab              Manage your tokens with a web interface
+    import [path]    Import from a Figma Design file
+      --o [file]     Save imported JSON
+      --unpublished  Include unpublished Variables
+      --skip-styles  Don’t import styles
+      --skip-variables
+                     Don’t import variables
 
   [options]
-    --help          Show this message
-    --config, -c    Path to config (default: ./terrazzo.config.ts)
-    --quiet         Suppress warnings
+    --help           Show this message
+    --config, -c     Path to config (default: ./terrazzo.config.ts)
+    --quiet          Suppress warnings
 `);
 }

--- a/packages/cli/src/import/figma/effect-style.ts
+++ b/packages/cli/src/import/figma/effect-style.ts
@@ -1,0 +1,22 @@
+import type { DropShadowEffect, InnerShadowEffect, Node } from '@figma/rest-api-spec';
+import type { ShadowValue } from '@terrazzo/token-tools';
+
+/** Return a shadow token from an effect */
+export function effectStyle(node: Node): ShadowValue[] | undefined {
+  if ('effects' in node) {
+    const shadows = node.effects.filter((e) => e.type === 'DROP_SHADOW' || e.type === 'INNER_SHADOW') as (
+      | DropShadowEffect
+      | InnerShadowEffect
+    )[];
+    if (shadows.length) {
+      return shadows.map((s) => ({
+        inset: s.type === 'INNER_SHADOW',
+        offsetX: { value: s.offset.x, unit: 'px' },
+        offsetY: { value: s.offset.y, unit: 'px' },
+        blur: { value: s.radius, unit: 'px' },
+        spread: { value: s.spread ?? 0, unit: 'px' },
+        color: { colorSpace: 'srgb', components: [s.color.r, s.color.g, s.color.b], alpha: s.color.a },
+      }));
+    }
+  }
+}

--- a/packages/cli/src/import/figma/fill-style.ts
+++ b/packages/cli/src/import/figma/fill-style.ts
@@ -1,0 +1,24 @@
+import type { Node } from '@figma/rest-api-spec';
+import type { ColorValue, GradientValue } from '@terrazzo/token-tools';
+
+/** Return a color or gradient token from a fill */
+export function fillStyle(node: Node): ColorValue | GradientValue | undefined {
+  if ('fills' in node) {
+    for (const fill of node.fills) {
+      switch (fill.type) {
+        case 'SOLID': {
+          return { colorSpace: 'srgb', components: [fill.color.r, fill.color.g, fill.color.b], alpha: fill.color.a };
+        }
+        case 'GRADIENT_LINEAR':
+        case 'GRADIENT_RADIAL':
+        case 'GRADIENT_ANGULAR':
+        case 'GRADIENT_DIAMOND': {
+          return fill.gradientStops.map((stop) => ({
+            position: stop.position,
+            color: { colorSpace: 'srgb', components: [stop.color.r, stop.color.g, stop.color.b], alpha: stop.color.a },
+          }));
+        }
+      }
+    }
+  }
+}

--- a/packages/cli/src/import/figma/index.ts
+++ b/packages/cli/src/import/figma/index.ts
@@ -1,0 +1,322 @@
+import type {
+  GetFileNodesResponse,
+  GetFileStylesResponse,
+  GetLocalVariablesResponse,
+  GetPublishedVariablesResponse,
+  LocalVariable,
+  LocalVariableCollection,
+  PublishedVariable,
+  PublishedVariableCollection,
+} from '@figma/rest-api-spec';
+import type { Logger } from '@terrazzo/parser';
+import { merge } from 'merge-anything';
+import { effectStyle } from './effect-style.js';
+import { fillStyle } from './fill-style.js';
+import { textStyle } from './text-style.js';
+
+export interface importFromFigmaOptions {
+  url: string;
+  logger: Logger;
+  /** Grab unpublished Styles/Variables @default false */
+  unpublished?: boolean;
+  skipStyles?: boolean;
+  skipVariables?: boolean;
+}
+
+export interface FigmaOutput {
+  variableCount: number;
+  styleCount: number;
+  /** The Resolver JSON, in object format (could be any shape) */
+  code: Record<string, any>;
+}
+
+const KEY = ':key';
+const FILE_KEY = ':file_key';
+const API = {
+  fileNodes: `https://api.figma.com/v1/files/${FILE_KEY}/nodes`,
+  fileStyles: `https://api.figma.com/v1/files/${FILE_KEY}/styles`,
+  localVariables: `https://api.figma.com/v1/files/${FILE_KEY}/variables/local`,
+  publishedVariables: `https://api.figma.com/v1/files/${FILE_KEY}/variables/published`,
+  styles: `https://api.figma.com/v1/styles/${KEY}`,
+};
+
+export async function importFromFigma({
+  url,
+  logger,
+  unpublished,
+  skipStyles,
+  skipVariables,
+}: importFromFigmaOptions): Promise<FigmaOutput> {
+  const fileKey = getFileID(url);
+  if (!fileKey) {
+    logger.error({ group: 'import', message: `Invalid Figma URL: ${url}` });
+  }
+
+  const result: FigmaOutput = {
+    variableCount: 0,
+    styleCount: 0,
+    code: {
+      $schema: 'https://www.designtokens.org/schemas/2025.10/resolver.json',
+      version: '2025.10',
+      resolutionOrder: [],
+      sets: {},
+      modifiers: {},
+    },
+  };
+
+  try {
+    const [styles, vars] = await Promise.all([
+      ...(!skipStyles ? [getStyles(fileKey!, { logger })] : []),
+      ...(!skipVariables ? [getVariables(fileKey!, { logger, unpublished })] : []),
+    ]);
+    if (styles) {
+      result.styleCount += styles.count;
+      result.code = merge(result.code, styles.code);
+    }
+    if (vars) {
+      result.variableCount += vars.count;
+      result.code = merge(result.code, vars.code);
+    }
+  } catch (err) {
+    logger.error({ group: 'import', message: (err as Error).message });
+  }
+
+  return result;
+}
+
+/** Is this a valid URL, and one belonging to a Figma file? */
+export function isFigmaPath(url: string) {
+  try {
+    new URL(url);
+    return /^https:\/\/(www\.)?figma\.com\/design\/[A-Za-z0-9]+/.test(url);
+  } catch {
+    return false;
+  }
+}
+
+/** Get File ID from design URL */
+export function getFileID(url: string) {
+  return url.match(/^https:\/\/(www\.)?figma\.com\/design\/([^/]+)/)?.[2];
+}
+
+/** /v1/files/:file_key/nodes */
+export async function getFileNodes(fileKey: string, { ids, logger }: { logger: Logger; ids?: string[] }) {
+  let url = API.fileNodes.replace(FILE_KEY, fileKey);
+  if (ids?.length) {
+    url += `?ids=${ids.join(',')}`;
+  }
+  const fileRes = await fetch(url, {
+    method: 'GET',
+    headers: { 'X-Figma-Token': process.env.FIGMA_ACCESS_TOKEN! },
+  });
+  if (!fileRes.ok) {
+    logger.error({ group: 'import', message: `${fileRes.status} ${await fileRes.text()}` });
+  }
+  return (await fileRes.json()) as GetFileNodesResponse;
+}
+
+export interface TokenExport {
+  count: number;
+  code: Record<string, any>;
+}
+
+/** /v1/files/:file_key/styles */
+export async function getStyles(
+  fileKey: string,
+  { logger }: Pick<importFromFigmaOptions, 'logger'>,
+): Promise<TokenExport> {
+  const result: TokenExport = {
+    count: 0,
+    code: {
+      sets: {
+        styles: {
+          sources: [{}],
+        },
+      },
+    },
+  };
+
+  const stylesRes = await fetch(API.fileStyles.replace(FILE_KEY, fileKey), {
+    method: 'GET',
+    headers: { 'X-Figma-Token': process.env.FIGMA_ACCESS_TOKEN! },
+  });
+  if (!stylesRes.ok) {
+    logger.error({ group: 'import', message: `${stylesRes.status} ${await stylesRes.text()}` });
+  }
+  const styles = (await stylesRes.json()) as GetFileStylesResponse;
+
+  const fileNodes = await getFileNodes(fileKey, { ids: styles.meta.styles.map((s) => s.node_id), logger });
+
+  result.count += styles.meta.styles.length;
+  for (const s of styles.meta.styles) {
+    let node = result.code.sets.styles.sources[0];
+    const path = s.name.split('/');
+    const name = path.pop()!;
+    for (const key of path) {
+      if (!(key in node)) {
+        node[key] = {};
+      }
+      node = node[key];
+    }
+
+    node[name] = {
+      $description: s.description || undefined,
+      $extensions: {
+        'figma.com': {
+          name: s.name,
+          node_id: s.node_id,
+          created_at: s.created_at,
+          updated_at: s.updated_at,
+        },
+      },
+    };
+
+    switch (s.style_type) {
+      case 'FILL': {
+        node[name].$type = 'color';
+        const $value = fillStyle(fileNodes.nodes[s.node_id]!.document);
+        if (!$value) {
+          logger.error({ group: 'import', message: `Could not parse fill for ${s.name}`, continueOnError: true });
+        }
+        node[name].$value = $value;
+        break;
+      }
+      case 'TEXT': {
+        node[name].$type = 'typography';
+        const $value = textStyle(fileNodes.nodes[s.node_id]!.document);
+        if (!$value) {
+          logger.error({ group: 'import', message: `Could not parse text for ${s.name}`, continueOnError: true });
+        }
+        node[name].$value = $value;
+        break;
+      }
+      case 'EFFECT': {
+        node[name].$type = 'shadow';
+        const $value = effectStyle(fileNodes.nodes[s.node_id]!.document);
+        if (!$value) {
+          logger.error({ group: 'import', message: `Could not parse effect for ${s.name}`, continueOnError: true });
+        }
+        node[name].$value = $value;
+        break;
+      }
+      case 'GRID': {
+        logger.error({ group: 'import', message: `Could not parse grid for ${s.name}`, continueOnError: true });
+        break;
+      }
+    }
+  }
+
+  return result;
+}
+
+/** /v1/files/:file_key/variables/published | /v1/files/:file_key/variables/local */
+export async function getVariables(
+  fileKey: string,
+  { logger, unpublished }: Pick<importFromFigmaOptions, 'logger' | 'unpublished'>,
+): Promise<TokenExport> {
+  const result: TokenExport = {
+    count: 0,
+    code: { sets: {} },
+  };
+
+  const variables: Record<string, LocalVariable | PublishedVariable> = {};
+  const variableCollections: Record<string, LocalVariableCollection | PublishedVariableCollection> = {};
+
+  if (unpublished !== true) {
+    const publishedRes = await fetch(API.publishedVariables.replace(FILE_KEY, fileKey), {
+      method: 'GET',
+      headers: { 'X-Figma-Token': process.env.FIGMA_ACCESS_TOKEN! },
+    });
+    if (!publishedRes.ok) {
+      logger.error({ group: 'import', message: `${publishedRes.status} ${await publishedRes.text()}` });
+    }
+    const published = (await publishedRes.json()) as GetPublishedVariablesResponse;
+    for (const id of Object.keys(published.meta.variables)) {
+      result.count++;
+      variables[id] = published.meta.variables[id]!;
+    }
+    for (const id of Object.keys(published.meta.variableCollections)) {
+      variableCollections[id] = published.meta.variableCollections[id]!;
+    }
+  }
+  if (unpublished || !result.count) {
+    const localRes = await fetch(API.localVariables.replace(FILE_KEY, fileKey), {
+      method: 'GET',
+      headers: { 'X-Figma-Token': process.env.FIGMA_ACCESS_TOKEN! },
+    });
+    if (!localRes.ok) {
+      logger.error({ group: 'import', message: `${localRes.status} ${await localRes.text}` });
+    }
+    const local = (await localRes.json()) as GetLocalVariablesResponse;
+    for (const id of Object.keys(local.meta.variables)) {
+      result.count++;
+      variables[id] = local.meta.variables[id]!;
+    }
+    for (const id of Object.keys(local.meta.variableCollections)) {
+      variableCollections[id] = local.meta.variableCollections[id]!;
+    }
+  }
+
+  for (const id of Object.keys(variables)) {
+    const variable = variables[id]!;
+
+    if (
+      ('remote' in variable && variable.remote) ||
+      ('hiddenFromPublishing' in variable && variable.hiddenFromPublishing)
+    ) {
+      continue;
+    }
+
+    const collection = variableCollections[variable.variableCollectionId]!;
+    if (!(collection.name in result.code.sets)) {
+      result.code.sets[collection.name] = { sources: [] };
+    }
+    let node = result.code.sets[collection.name].sources[0];
+    const path = variable.name.split('/');
+    const name = path.pop()!;
+    for (const key of path) {
+      if (!(key in node)) {
+        node[key] = {};
+      }
+      node = node[key];
+    }
+
+    node[name] = {
+      $description: (variable as LocalVariable).description || undefined,
+      $extensions: {
+        'figma.com': {
+          name: variable.name,
+          id: variable.id,
+          key: variable.key,
+          subscribed_id: (variable as PublishedVariable).subscribed_id,
+          updated_at: (variable as PublishedVariable).updatedAt,
+        },
+      },
+    };
+    const variableType = 'resolvedDataType' in variable ? variable.resolvedDataType : variable.resolvedType;
+    switch (variableType) {
+      case 'BOOLEAN': {
+        node[name].$type = 'boolean';
+        node[name].$value = false;
+        break;
+      }
+      case 'FLOAT': {
+        node[name].$type = 'number';
+        node[name].$value = 0.123;
+        break;
+      }
+      case 'STRING': {
+        node[name].$type = 'string';
+        node[name].$value = 'foo';
+        break;
+      }
+      case 'COLOR': {
+        node[name].$type = 'color';
+        node[name].$value = { colorSpace: 'srgb', components: [], alpha: 1 };
+        break;
+      }
+    }
+  }
+
+  return result;
+}

--- a/packages/cli/src/import/figma/text-style.ts
+++ b/packages/cli/src/import/figma/text-style.ts
@@ -1,0 +1,21 @@
+import type { Node } from '@figma/rest-api-spec';
+import type { TypographyValue } from '@terrazzo/token-tools';
+
+/** Return a typography token from text */
+export function textStyle(node: Node): TypographyValue | undefined {
+  if ('style' in node) {
+    return {
+      fontFamily: [node.style.fontFamily!],
+      fontWeight: node.style.fontWeight,
+      fontStyle: node.style.fontStyle,
+      fontSize: node.style.fontSize ? { value: node.style.fontSize, unit: 'px' } : { value: 1, unit: 'em' },
+      letterSpacing: { value: node.style.letterSpacing ?? 0, unit: 'px' },
+      lineHeight:
+        'lineHeightPercentFontSize' in node.style
+          ? node.style.lineHeightPercentFontSize!
+          : 'lineHeightPx' in node.style
+            ? { value: node.style.lineHeightPx!, unit: 'px' }
+            : 1,
+    };
+  }
+}

--- a/packages/cli/src/import/index.ts
+++ b/packages/cli/src/import/index.ts
@@ -1,0 +1,75 @@
+import fsSync from 'node:fs';
+import fs from 'node:fs/promises';
+import type { Logger } from '@terrazzo/parser';
+import { pluralize } from '@terrazzo/token-tools';
+import { importFromFigma, isFigmaPath } from './figma/index.js';
+
+export * from './figma/index.js';
+
+export interface ImportCmdOptions {
+  flags: {
+    /** The output file @default stdout */
+    output?: string;
+  } & Record<string, any>;
+  positionals: string[];
+  logger: Logger;
+}
+
+const nf = new Intl.NumberFormat('en-us');
+
+export async function importCmd({ flags, positionals, logger }: ImportCmdOptions) {
+  const [_cmd, url] = positionals;
+  if (!url) {
+    logger.error({
+      group: 'import',
+      message: 'Missing import path. Expected `tz import [file]`.',
+    });
+  }
+
+  if (isFigmaPath(url!)) {
+    const { FIGMA_ACCESS_TOKEN } = process.env;
+    if (!FIGMA_ACCESS_TOKEN) {
+      logger.error({
+        group: 'import',
+        message: `FIGMA_ACCESS_TOKEN not set! See https://terrazzo.app/docs/guides/import-from-figma`,
+      });
+    }
+
+    const start = performance.now();
+    const result = await importFromFigma({
+      url: url!,
+      logger,
+      unpublished: flags.unpublished,
+      skipStyles: flags['skip-styles'],
+      skipVariables: flags['skip-variables'],
+    });
+    const end = performance.now() - start;
+
+    if (flags.output) {
+      const oldFile = fsSync.existsSync(flags.output) ? JSON.parse(await fs.readFile(flags.output, 'utf8')) : {};
+      // merge with old file, if any
+      const code = {
+        $schema: result.code.$schema, // Reset $schema
+        version: result.code.version, // Reset version
+        // Note: it’s important to have resolutionOrder higher up, since sets and modifiers will be a mess
+        resolutionOrder: oldFile.resolutionOrder ?? result.code.resolutionOrder, // Rely on old file, since the Figma file won’t understand resolutionOrder
+        sets: result.code.sets, // Overwrite old sets
+        modifiers: result.code.modifiers, // Overwrite old modifiers
+        $defs: oldFile.$defs, // Just in case
+        $extensions: oldFile.$extensions, // Just in case
+      };
+      await fs.writeFile(flags.output, `${JSON.stringify(code, undefined, 2)}\n`);
+      logger.info({
+        group: 'import',
+        message: `Imported ${nf.format(result.variableCount)} ${pluralize(result.variableCount, 'Variable', 'Variables')}, ${nf.format(result.styleCount)} ${pluralize(result.styleCount, 'Style', 'Styles')} → ${flags.output}`,
+        timing: end,
+      });
+    } else {
+      process.stdout.write(JSON.stringify(result.code));
+    }
+
+    return;
+  }
+
+  // Other imports here
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import { cwd } from './shared.js';
 export * from './build.js';
 export * from './check.js';
 export * from './help.js';
+export * from './import/index.js';
 export * from './init.js';
 export * from './lab.js';
 export * from './normalize.js';
@@ -29,6 +30,7 @@ export function defineConfig(config: Config): ConfigInit {
       try {
         return pathToFileURL(require.resolve(tokenPath));
       } catch (err) {
+        // biome-ignore lint/suspicious/noConsole: this is its job
         console.error(err);
         // this will throw an error if Node couldn’t automatically resolve it,
         // which will be true for many token paths. We don’t need to surface

--- a/packages/cli/src/shared.ts
+++ b/packages/cli/src/shared.ts
@@ -220,11 +220,13 @@ export async function loadTokens(tokenPaths: URL[], { logger }: { logger: Logger
 
 /** Print error */
 export function printError(message: string) {
+  // biome-ignore lint/suspicious/noConsole: this is its job
   console.error(pc.red(`✗  ${message}`));
 }
 
 /** Print success */
 export function printSuccess(message: string, startTime?: number) {
+  // biome-ignore lint/suspicious/noConsole: this is its job
   console.log(`${GREEN_CHECK}  ${message}${startTime ? ` ${time(startTime)}` : ''}`);
 }
 

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,5 +2,6 @@ import fs from 'node:fs';
 
 export function versionCmd() {
   const { version } = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+  // biome-ignore lint/suspicious/noConsole: this is its job
   console.log(version);
 }

--- a/packages/cli/test/build.test.ts
+++ b/packages/cli/test/build.test.ts
@@ -26,7 +26,7 @@ describe('tz build', () => {
       await expect(() => execa('node', [cmd, 'build'], { cwd })).rejects.toThrowErrorMatchingInlineSnapshot(`
         [ExecaError: Command failed with exit code 1: node ../../../bin/cli.js build
 
-        ✗  [config] Could not locate tokens.json. To create one, run \`npx tz init\`.]
+        ✗  config: Could not locate tokens.json. To create one, run \`npx tz init\`.]
       `);
     });
 
@@ -35,7 +35,7 @@ describe('tz build', () => {
       await expect(() => execa('node', [cmd, 'build'], { cwd })).rejects.toThrowErrorMatchingInlineSnapshot(`
         [ExecaError: Command failed with exit code 1: node ../../../bin/cli.js build
 
-        ✗  [config] No default export found in terrazzo.config.js. See https://terrazzo.dev/docs for instructions.]
+        ✗  config: No default export found in terrazzo.config.js. See https://terrazzo.dev/docs for instructions.]
       `);
     });
   });

--- a/packages/cli/test/check.test.ts
+++ b/packages/cli/test/check.test.ts
@@ -60,7 +60,7 @@ describe('tz check', () => {
     }
     await expect(
       command,
-    ).rejects.toThrowError(`✗  [lint:core/valid-color] Expected components to be array of numbers, received "[0, 0.2, 1]".
+    ).rejects.toThrowError(`✗  lint:core/valid-color: Expected components to be array of numbers, received "[0, 0.2, 1]".
 
   4 |       "100": {
   5 |         "$type": "color",
@@ -70,6 +70,6 @@ describe('tz check', () => {
   8 |     }
   9 |   }
 
-[lint:lint] 1 error`);
+lint:lint: 1 error`);
   });
 });

--- a/packages/cli/test/fixtures/import-figma/get-file-nodes.json
+++ b/packages/cli/test/fixtures/import-figma/get-file-nodes.json
@@ -1,0 +1,399 @@
+{
+  "name": "Variables Export Test",
+  "lastModified": "2025-10-30T12:00:00Z",
+  "version": "2317242489159095547",
+  "role": "owner",
+  "editorType": "figma",
+  "nodes": {
+    "16:3": {
+      "document": {
+        "id": "16:3",
+        "name": "elevation/100",
+        "type": "RECTANGLE",
+        "scrollBehavior": "SCROLLS",
+        "blendMode": "PASS_THROUGH",
+        "fills": [
+          {
+            "blendMode": "NORMAL",
+            "type": "SOLID",
+            "color": {
+              "r": 0.8509804010391235,
+              "g": 0.8509804010391235,
+              "b": 0.8509804010391235,
+              "a": 1
+            }
+          }
+        ],
+        "strokes": [],
+        "strokeWeight": 1,
+        "strokeAlign": "INSIDE",
+        "absoluteBoundingBox": {
+          "x": 0,
+          "y": 0,
+          "width": 100,
+          "height": 100
+        },
+        "absoluteRenderBounds": {
+          "x": -4,
+          "y": 0,
+          "width": 108,
+          "height": 108
+        },
+        "constraints": {
+          "vertical": "TOP",
+          "horizontal": "LEFT"
+        },
+        "effects": [
+          {
+            "type": "DROP_SHADOW",
+            "visible": true,
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0.25
+            },
+            "blendMode": "NORMAL",
+            "offset": {
+              "x": 0,
+              "y": 4
+            },
+            "radius": 4,
+            "showShadowBehindNode": false
+          }
+        ],
+        "interactions": [],
+        "complexStrokeProperties": {
+          "strokeType": "BASIC"
+        }
+      },
+      "components": {},
+      "componentSets": {},
+      "schemaVersion": 0,
+      "styles": {}
+    },
+    "4:3": {
+      "document": {
+        "id": "4:3",
+        "name": "text/body/medium",
+        "type": "TEXT",
+        "scrollBehavior": "SCROLLS",
+        "boundVariables": {
+          "lineHeight": [
+            {
+              "type": "VARIABLE_ALIAS",
+              "id": "VariableID:4:7"
+            }
+          ],
+          "fontFamily": [
+            {
+              "type": "VARIABLE_ALIAS",
+              "id": "VariableID:4:5"
+            }
+          ],
+          "fontSize": [
+            {
+              "type": "VARIABLE_ALIAS",
+              "id": "VariableID:4:8"
+            }
+          ]
+        },
+        "blendMode": "PASS_THROUGH",
+        "fills": [
+          {
+            "blendMode": "NORMAL",
+            "type": "SOLID",
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 1
+            }
+          }
+        ],
+        "strokes": [],
+        "strokeWeight": 0,
+        "strokeAlign": "INSIDE",
+        "absoluteBoundingBox": {
+          "x": 0,
+          "y": 0,
+          "width": 18,
+          "height": 1
+        },
+        "absoluteRenderBounds": {
+          "x": 0.4716796875,
+          "y": -4.8642578125,
+          "width": 15.9755859375,
+          "height": 12.4619140625
+        },
+        "constraints": {
+          "vertical": "TOP",
+          "horizontal": "LEFT"
+        },
+        "characters": "Ag",
+        "characterStyleOverrides": [],
+        "styleOverrideTable": {},
+        "lineTypes": [
+          "NONE"
+        ],
+        "lineIndentations": [
+          0
+        ],
+        "style": {
+          "fontFamily": "SF Pro",
+          "fontPostScriptName": "SFPro-Regular",
+          "fontStyle": "Regular",
+          "fontWeight": 400,
+          "textAutoResize": "WIDTH_AND_HEIGHT",
+          "fontSize": 14,
+          "textAlignHorizontal": "LEFT",
+          "textAlignVertical": "TOP",
+          "letterSpacing": 0,
+          "lineHeightPx": 1,
+          "lineHeightPercent": 5.985504150390625,
+          "lineHeightPercentFontSize": 7.142857074737549,
+          "lineHeightUnit": "PIXELS"
+        },
+        "layoutVersion": 5,
+        "effects": [],
+        "interactions": [],
+        "complexStrokeProperties": {
+          "strokeType": "BASIC"
+        }
+      },
+      "components": {},
+      "componentSets": {},
+      "schemaVersion": 0,
+      "styles": {}
+    },
+    "4:11": {
+      "document": {
+        "id": "4:11",
+        "name": "text/body/large",
+        "type": "TEXT",
+        "scrollBehavior": "SCROLLS",
+        "boundVariables": {
+          "lineHeight": [
+            {
+              "type": "VARIABLE_ALIAS",
+              "id": "VariableID:4:9"
+            }
+          ],
+          "fontFamily": [
+            {
+              "type": "VARIABLE_ALIAS",
+              "id": "VariableID:4:5"
+            }
+          ],
+          "fontSize": [
+            {
+              "type": "VARIABLE_ALIAS",
+              "id": "VariableID:4:10"
+            }
+          ]
+        },
+        "blendMode": "PASS_THROUGH",
+        "fills": [
+          {
+            "blendMode": "NORMAL",
+            "type": "SOLID",
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 1
+            }
+          }
+        ],
+        "strokes": [],
+        "strokeWeight": 0,
+        "strokeAlign": "INSIDE",
+        "absoluteBoundingBox": {
+          "x": 0,
+          "y": 0,
+          "width": 21,
+          "height": 1
+        },
+        "absoluteRenderBounds": {
+          "x": 0.5390625,
+          "y": -5.2734375,
+          "width": 18.2578125,
+          "height": 14.2421875
+        },
+        "constraints": {
+          "vertical": "TOP",
+          "horizontal": "LEFT"
+        },
+        "characters": "Ag",
+        "characterStyleOverrides": [],
+        "styleOverrideTable": {},
+        "lineTypes": [
+          "NONE"
+        ],
+        "lineIndentations": [
+          0
+        ],
+        "style": {
+          "fontFamily": "SF Pro",
+          "fontPostScriptName": "SFPro-Regular",
+          "fontStyle": "Regular",
+          "fontWeight": 400,
+          "textAutoResize": "WIDTH_AND_HEIGHT",
+          "fontSize": 16,
+          "textAlignHorizontal": "LEFT",
+          "textAlignVertical": "TOP",
+          "letterSpacing": 0,
+          "lineHeightPx": 1,
+          "lineHeightPercent": 5.237316131591797,
+          "lineHeightPercentFontSize": 6.25,
+          "lineHeightUnit": "PIXELS"
+        },
+        "layoutVersion": 5,
+        "effects": [],
+        "interactions": [],
+        "complexStrokeProperties": {
+          "strokeType": "BASIC"
+        }
+      },
+      "components": {},
+      "componentSets": {},
+      "schemaVersion": 0,
+      "styles": {}
+    },
+    "16:2": {
+      "document": {
+        "id": "16:2",
+        "name": "style/green/100",
+        "type": "RECTANGLE",
+        "scrollBehavior": "SCROLLS",
+        "blendMode": "PASS_THROUGH",
+        "fills": [
+          {
+            "blendMode": "NORMAL",
+            "type": "SOLID",
+            "color": {
+              "r": 0.2835651934146881,
+              "g": 0.8572100400924683,
+              "b": 0.369611918926239,
+              "a": 1
+            }
+          }
+        ],
+        "strokes": [],
+        "strokeWeight": 1,
+        "strokeAlign": "INSIDE",
+        "absoluteBoundingBox": {
+          "x": 0,
+          "y": 0,
+          "width": 100,
+          "height": 100
+        },
+        "absoluteRenderBounds": {
+          "x": 0,
+          "y": 0,
+          "width": 100,
+          "height": 100
+        },
+        "constraints": {
+          "vertical": "TOP",
+          "horizontal": "LEFT"
+        },
+        "effects": [],
+        "interactions": [],
+        "complexStrokeProperties": {
+          "strokeType": "BASIC"
+        }
+      },
+      "components": {},
+      "componentSets": {},
+      "schemaVersion": 0,
+      "styles": {}
+    },
+    "16:4": {
+      "document": {
+        "id": "16:4",
+        "name": "style/gradient/100",
+        "type": "RECTANGLE",
+        "scrollBehavior": "SCROLLS",
+        "blendMode": "PASS_THROUGH",
+        "fills": [
+          {
+            "blendMode": "NORMAL",
+            "type": "GRADIENT_LINEAR",
+            "gradientHandlePositions": [
+              {
+                "x": 0.5,
+                "y": -3.0616171314629196e-17
+              },
+              {
+                "x": 0.5,
+                "y": 0.9999999999999999
+              },
+              {
+                "x": 0,
+                "y": 0
+              }
+            ],
+            "gradientStops": [
+              {
+                "color": {
+                  "r": 0.9221681356430054,
+                  "g": 0.0945836678147316,
+                  "b": 0.0945836678147316,
+                  "a": 1
+                },
+                "position": 0
+              },
+              {
+                "color": {
+                  "r": 0.18287979066371918,
+                  "g": 0.2011471837759018,
+                  "b": 0.5482274889945984,
+                  "a": 1
+                },
+                "position": 0.33173078298568726
+              },
+              {
+                "color": {
+                  "r": 0.7361242175102234,
+                  "g": 0.18885448575019836,
+                  "b": 0.9351313710212708,
+                  "a": 1
+                },
+                "position": 1
+              }
+            ]
+          }
+        ],
+        "strokes": [],
+        "strokeWeight": 1,
+        "strokeAlign": "INSIDE",
+        "absoluteBoundingBox": {
+          "x": 0,
+          "y": 0,
+          "width": 100,
+          "height": 100
+        },
+        "absoluteRenderBounds": {
+          "x": 0,
+          "y": 0,
+          "width": 100,
+          "height": 100
+        },
+        "constraints": {
+          "vertical": "TOP",
+          "horizontal": "LEFT"
+        },
+        "effects": [],
+        "interactions": [],
+        "complexStrokeProperties": {
+          "strokeType": "BASIC"
+        }
+      },
+      "components": {},
+      "componentSets": {},
+      "schemaVersion": 0,
+      "styles": {}
+    }
+  }
+}

--- a/packages/cli/test/fixtures/import-figma/get-local-variables.json
+++ b/packages/cli/test/fixtures/import-figma/get-local-variables.json
@@ -1,0 +1,6 @@
+{
+  "meta": {
+    "variables": {},
+    "variableCollections": {}
+  }
+}

--- a/packages/cli/test/fixtures/import-figma/get-published-variables.json
+++ b/packages/cli/test/fixtures/import-figma/get-published-variables.json
@@ -1,0 +1,6 @@
+{
+  "meta": {
+    "variables": {},
+    "variableCollections": {}
+  }
+}

--- a/packages/cli/test/fixtures/import-figma/get-styles.json
+++ b/packages/cli/test/fixtures/import-figma/get-styles.json
@@ -1,0 +1,64 @@
+{
+  "error": false,
+  "status": 200,
+  "meta": {
+    "styles": [
+      {
+        "key": "5706e062721a96556d321af763097aa1c8d8eb1c",
+        "file_key": ":file_key",
+        "node_id": "16:3",
+        "style_type": "EFFECT",
+        "name": "elevation/100",
+        "description": "Default shadow.",
+        "created_at": "2025-10-30T12:00:00Z",
+        "updated_at": "2025-10-30T12:00:00Z",
+        "user": {}
+      },
+      {
+        "key": "b2079c5e25ef3a330ff92c173487ec0fbc406eb6",
+        "file_key": ":file_key",
+        "node_id": "4:3",
+        "style_type": "TEXT",
+        "name": "text/body/medium",
+        "description": "Default body text style.",
+        "created_at": "2025-10-30T12:00:00Z",
+        "updated_at": "2025-10-30T12:00:00Z",
+        "user": {}
+      },
+      {
+        "key": "421ab6dfaf40958be927a5e20d5c6a0d9d419f0b",
+        "file_key": ":file_key",
+        "node_id": "4:11",
+        "style_type": "TEXT",
+        "name": "text/body/large",
+        "description": "Large body text style.",
+        "created_at": "2025-10-30T12:00:00Z",
+        "updated_at": "2025-10-30T12:00:00Z",
+        "user": {}
+      },
+      {
+        "key": "783ebbacdd204a8bab90e9c9115aa3f75751ea96",
+        "file_key": ":file_key",
+        "node_id": "16:2",
+        "style_type": "FILL",
+        "name": "style/green/100",
+        "description": "",
+        "created_at": "2025-10-30T12:00:00Z",
+        "updated_at": "2025-10-30T12:00:00Z",
+        "user": {}
+      },
+      {
+        "key": "6cd916da62c28968d21fc26660506cb679ea75e6",
+        "file_key": ":file_key",
+        "node_id": "16:4",
+        "style_type": "FILL",
+        "name": "style/gradient/100",
+        "description": "",
+        "created_at": "2025-10-30T12:00:00Z",
+        "updated_at": "2025-10-30T12:00:00Z",
+        "user": {}
+      }
+    ]
+  },
+  "i18n": null
+}

--- a/packages/cli/test/fixtures/import-figma/import-both.want.json
+++ b/packages/cli/test/fixtures/import-figma/import-both.want.json
@@ -1,0 +1,193 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/resolver.json",
+  "version": "2025.10",
+  "resolutionOrder": [],
+  "sets": {
+    "styles": {
+      "sources": [
+        {
+          "elevation": {
+            "100": {
+              "$description": "Default shadow.",
+              "$extensions": {
+                "figma.com": {
+                  "name": "elevation/100",
+                  "node_id": "16:3",
+                  "created_at": "2025-10-30T12:00:00Z",
+                  "updated_at": "2025-10-30T12:00:00Z"
+                }
+              },
+              "$type": "shadow",
+              "$value": [
+                {
+                  "inset": false,
+                  "offsetX": {
+                    "value": 0,
+                    "unit": "px"
+                  },
+                  "offsetY": {
+                    "value": 4,
+                    "unit": "px"
+                  },
+                  "blur": {
+                    "value": 4,
+                    "unit": "px"
+                  },
+                  "spread": {
+                    "value": 0,
+                    "unit": "px"
+                  },
+                  "color": {
+                    "colorSpace": "srgb",
+                    "components": [
+                      0,
+                      0,
+                      0
+                    ],
+                    "alpha": 0.25
+                  }
+                }
+              ]
+            }
+          },
+          "text": {
+            "body": {
+              "medium": {
+                "$description": "Default body text style.",
+                "$extensions": {
+                  "figma.com": {
+                    "name": "text/body/medium",
+                    "node_id": "4:3",
+                    "created_at": "2025-10-30T12:00:00Z",
+                    "updated_at": "2025-10-30T12:00:00Z"
+                  }
+                },
+                "$type": "typography",
+                "$value": {
+                  "fontFamily": [
+                    "SF Pro"
+                  ],
+                  "fontWeight": 400,
+                  "fontStyle": "Regular",
+                  "fontSize": {
+                    "value": 14,
+                    "unit": "px"
+                  },
+                  "letterSpacing": {
+                    "value": 0,
+                    "unit": "px"
+                  },
+                  "lineHeight": 7.142857074737549
+                }
+              },
+              "large": {
+                "$description": "Large body text style.",
+                "$extensions": {
+                  "figma.com": {
+                    "name": "text/body/large",
+                    "node_id": "4:11",
+                    "created_at": "2025-10-30T12:00:00Z",
+                    "updated_at": "2025-10-30T12:00:00Z"
+                  }
+                },
+                "$type": "typography",
+                "$value": {
+                  "fontFamily": [
+                    "SF Pro"
+                  ],
+                  "fontWeight": 400,
+                  "fontStyle": "Regular",
+                  "fontSize": {
+                    "value": 16,
+                    "unit": "px"
+                  },
+                  "letterSpacing": {
+                    "value": 0,
+                    "unit": "px"
+                  },
+                  "lineHeight": 6.25
+                }
+              }
+            }
+          },
+          "style": {
+            "green": {
+              "100": {
+                "$extensions": {
+                  "figma.com": {
+                    "name": "style/green/100",
+                    "node_id": "16:2",
+                    "created_at": "2025-10-30T12:00:00Z",
+                    "updated_at": "2025-10-30T12:00:00Z"
+                  }
+                },
+                "$type": "color",
+                "$value": {
+                  "colorSpace": "srgb",
+                  "components": [
+                    0.2835651934146881,
+                    0.8572100400924683,
+                    0.369611918926239
+                  ],
+                  "alpha": 1
+                }
+              }
+            },
+            "gradient": {
+              "100": {
+                "$extensions": {
+                  "figma.com": {
+                    "name": "style/gradient/100",
+                    "node_id": "16:4",
+                    "created_at": "2025-10-30T12:00:00Z",
+                    "updated_at": "2025-10-30T12:00:00Z"
+                  }
+                },
+                "$type": "color",
+                "$value": [
+                  {
+                    "position": 0,
+                    "color": {
+                      "colorSpace": "srgb",
+                      "components": [
+                        0.9221681356430054,
+                        0.0945836678147316,
+                        0.0945836678147316
+                      ],
+                      "alpha": 1
+                    }
+                  },
+                  {
+                    "position": 0.33173078298568726,
+                    "color": {
+                      "colorSpace": "srgb",
+                      "components": [
+                        0.18287979066371918,
+                        0.2011471837759018,
+                        0.5482274889945984
+                      ],
+                      "alpha": 1
+                    }
+                  },
+                  {
+                    "position": 1,
+                    "color": {
+                      "colorSpace": "srgb",
+                      "components": [
+                        0.7361242175102234,
+                        0.18885448575019836,
+                        0.9351313710212708
+                      ],
+                      "alpha": 1
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "modifiers": {}
+}

--- a/packages/cli/test/fixtures/import-figma/import-styles.want.json
+++ b/packages/cli/test/fixtures/import-figma/import-styles.want.json
@@ -1,0 +1,193 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/resolver.json",
+  "version": "2025.10",
+  "resolutionOrder": [],
+  "sets": {
+    "styles": {
+      "sources": [
+        {
+          "elevation": {
+            "100": {
+              "$description": "Default shadow.",
+              "$extensions": {
+                "figma.com": {
+                  "name": "elevation/100",
+                  "node_id": "16:3",
+                  "created_at": "2025-10-30T12:00:00Z",
+                  "updated_at": "2025-10-30T12:00:00Z"
+                }
+              },
+              "$type": "shadow",
+              "$value": [
+                {
+                  "inset": false,
+                  "offsetX": {
+                    "value": 0,
+                    "unit": "px"
+                  },
+                  "offsetY": {
+                    "value": 4,
+                    "unit": "px"
+                  },
+                  "blur": {
+                    "value": 4,
+                    "unit": "px"
+                  },
+                  "spread": {
+                    "value": 0,
+                    "unit": "px"
+                  },
+                  "color": {
+                    "colorSpace": "srgb",
+                    "components": [
+                      0,
+                      0,
+                      0
+                    ],
+                    "alpha": 0.25
+                  }
+                }
+              ]
+            }
+          },
+          "text": {
+            "body": {
+              "medium": {
+                "$description": "Default body text style.",
+                "$extensions": {
+                  "figma.com": {
+                    "name": "text/body/medium",
+                    "node_id": "4:3",
+                    "created_at": "2025-10-30T12:00:00Z",
+                    "updated_at": "2025-10-30T12:00:00Z"
+                  }
+                },
+                "$type": "typography",
+                "$value": {
+                  "fontFamily": [
+                    "SF Pro"
+                  ],
+                  "fontWeight": 400,
+                  "fontStyle": "Regular",
+                  "fontSize": {
+                    "value": 14,
+                    "unit": "px"
+                  },
+                  "letterSpacing": {
+                    "value": 0,
+                    "unit": "px"
+                  },
+                  "lineHeight": 7.142857074737549
+                }
+              },
+              "large": {
+                "$description": "Large body text style.",
+                "$extensions": {
+                  "figma.com": {
+                    "name": "text/body/large",
+                    "node_id": "4:11",
+                    "created_at": "2025-10-30T12:00:00Z",
+                    "updated_at": "2025-10-30T12:00:00Z"
+                  }
+                },
+                "$type": "typography",
+                "$value": {
+                  "fontFamily": [
+                    "SF Pro"
+                  ],
+                  "fontWeight": 400,
+                  "fontStyle": "Regular",
+                  "fontSize": {
+                    "value": 16,
+                    "unit": "px"
+                  },
+                  "letterSpacing": {
+                    "value": 0,
+                    "unit": "px"
+                  },
+                  "lineHeight": 6.25
+                }
+              }
+            }
+          },
+          "style": {
+            "green": {
+              "100": {
+                "$extensions": {
+                  "figma.com": {
+                    "name": "style/green/100",
+                    "node_id": "16:2",
+                    "created_at": "2025-10-30T12:00:00Z",
+                    "updated_at": "2025-10-30T12:00:00Z"
+                  }
+                },
+                "$type": "color",
+                "$value": {
+                  "colorSpace": "srgb",
+                  "components": [
+                    0.2835651934146881,
+                    0.8572100400924683,
+                    0.369611918926239
+                  ],
+                  "alpha": 1
+                }
+              }
+            },
+            "gradient": {
+              "100": {
+                "$extensions": {
+                  "figma.com": {
+                    "name": "style/gradient/100",
+                    "node_id": "16:4",
+                    "created_at": "2025-10-30T12:00:00Z",
+                    "updated_at": "2025-10-30T12:00:00Z"
+                  }
+                },
+                "$type": "color",
+                "$value": [
+                  {
+                    "position": 0,
+                    "color": {
+                      "colorSpace": "srgb",
+                      "components": [
+                        0.9221681356430054,
+                        0.0945836678147316,
+                        0.0945836678147316
+                      ],
+                      "alpha": 1
+                    }
+                  },
+                  {
+                    "position": 0.33173078298568726,
+                    "color": {
+                      "colorSpace": "srgb",
+                      "components": [
+                        0.18287979066371918,
+                        0.2011471837759018,
+                        0.5482274889945984
+                      ],
+                      "alpha": 1
+                    }
+                  },
+                  {
+                    "position": 1,
+                    "color": {
+                      "colorSpace": "srgb",
+                      "components": [
+                        0.7361242175102234,
+                        0.18885448575019836,
+                        0.9351313710212708
+                      ],
+                      "alpha": 1
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "modifiers": {}
+}

--- a/packages/cli/test/fixtures/import-figma/import-variables.want.json
+++ b/packages/cli/test/fixtures/import-figma/import-variables.want.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/resolver.json",
+  "version": "2025.10",
+  "resolutionOrder": [],
+  "sets": {},
+  "modifiers": {}
+}

--- a/packages/cli/test/import.test.ts
+++ b/packages/cli/test/import.test.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { Logger } from '@terrazzo/parser';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { importCmd } from '../src/index.js';
+
+vi.stubEnv('FIGMA_ACCESS_TOKEN', 'fig_fake_token');
+
+const originalFetch = globalThis.fetch;
+
+describe('import', () => {
+  describe('figma', async () => {
+    const cwd = new URL('./fixtures/import-figma/', import.meta.url);
+
+    const FILE_KEY = 'AaAaAaAaAaAaAaAaAa';
+    const FIGMA_GET_FILE_NODES = await fs.readFile(new URL('get-file-nodes.json', cwd), 'utf8');
+    const FIGMA_GET_LOCAL_VARIABLES = await fs.readFile(new URL('get-local-variables.json', cwd), 'utf8');
+    const FIGMA_GET_PUBLISHED_VARIABLES = await fs.readFile(new URL('get-published-variables.json', cwd), 'utf8');
+    const FIGMA_GET_STYLES = await fs.readFile(new URL('get-styles.json', cwd), 'utf8');
+
+    beforeEach(() => {
+      globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+        return Promise.resolve(
+          new Response(
+            {
+              [`https://api.figma.com/v1/files/${FILE_KEY}/nodes`]: FIGMA_GET_FILE_NODES,
+              [`https://api.figma.com/v1/files/${FILE_KEY}/styles`]: FIGMA_GET_STYLES,
+              [`https://api.figma.com/v1/files/${FILE_KEY}/variables/local`]: FIGMA_GET_LOCAL_VARIABLES,
+              [`https://api.figma.com/v1/files/${FILE_KEY}/variables/published`]: FIGMA_GET_PUBLISHED_VARIABLES,
+            }[url.replace(/\?.*$/, '')],
+          ),
+        );
+      });
+    });
+
+    afterAll(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('both', async () => {
+      await importCmd({
+        logger: new Logger(),
+        positionals: ['import', `https://www.figma.com/design/${FILE_KEY}/My-File?node-id=1:1`],
+        flags: { output: 'test/fixtures/import-figma/import-both.actual.json' },
+      });
+      await expect(await fs.readFile(new URL('import-both.actual.json', cwd), 'utf8')).toMatchFileSnapshot(
+        fileURLToPath(new URL('import-both.want.json', cwd)),
+      );
+    });
+
+    it('styles only', async () => {
+      await importCmd({
+        logger: new Logger(),
+        positionals: ['import', `https://www.figma.com/design/${FILE_KEY}/My-File?node-id=1:1`],
+        flags: { output: 'test/fixtures/import-figma/import-styles.actual.json', 'skip-variables': true },
+      });
+      await expect(await fs.readFile(new URL('import-styles.actual.json', cwd), 'utf8')).toMatchFileSnapshot(
+        fileURLToPath(new URL('import-styles.want.json', cwd)),
+      );
+    });
+
+    it('variables only', async () => {
+      await importCmd({
+        logger: new Logger(),
+        positionals: ['import', `https://www.figma.com/design/${FILE_KEY}/My-File?node-id=1:1`],
+        flags: { output: 'test/fixtures/import-figma/import-variables.actual.json', 'skip-styles': true },
+      });
+      await expect(await fs.readFile(new URL('import-variables.actual.json', cwd), 'utf8')).toMatchFileSnapshot(
+        fileURLToPath(new URL('import-variables.want.json', cwd)),
+      );
+    });
+  });
+});

--- a/packages/cli/test/normalize.test.ts
+++ b/packages/cli/test/normalize.test.ts
@@ -27,7 +27,7 @@ describe('tz normalize', () => {
     await expect(execa(cmd, ['normalize', '--output', 'actual.json'], { cwd })).rejects.toThrow(
       `Command failed with exit code 1: ../../../bin/cli.js normalize --output actual.json
 
-✗  [config] Expected input: \`tz normalize <tokens.json> -o output.json\``,
+✗  config: Expected input: \`tz normalize <tokens.json> -o output.json\``,
     );
   });
 });

--- a/packages/parser/CHANGELOG.md
+++ b/packages/parser/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 2.0.0
 
+The 2.0.0 release is full of new features:
+
+- Full support for the DTCG v2025.10 spec, including resolvers
+- New and improved [native Figma import](https://terrazzo.app/docs/guides/import-from-figma)
+- `@terrazzo/plugin-js` was reimagined as a resolver API to build your own token machine (server-side)
+- `@terrazzo/plugin-css-in-js` was added as the missing solution for type-safe JS to use in any CSS-in-JS library
+- And of course dozens of bugfixes and quality of life improvements
+
 ### Minor Changes
 
 - [#530](https://github.com/terrazzoapp/terrazzo/pull/530) [`370ed7b`](https://github.com/terrazzoapp/terrazzo/commit/370ed7b0f578a64824124145d7f4936536b37bb3) Thanks [@drwpow](https://github.com/drwpow)! - ⚠️ Breaking change; DTCG 2nd Editors draft format will throw errors by default. This means converting all colors and dimensions to the new object format.

--- a/packages/parser/src/config.ts
+++ b/packages/parser/src/config.ts
@@ -75,16 +75,14 @@ function normalizeTokens({
       } else {
         logger.error({
           group: 'config',
-          label: 'tokens',
-          message: `Expected array of strings, encountered ${JSON.stringify(file)}`,
+          message: `tokens: Expected array of strings, encountered ${JSON.stringify(file)}`,
         });
       }
     }
   } else {
     logger.error({
       group: 'config',
-      label: 'tokens',
-      message: `Expected string or array of strings, received ${typeof rawConfig.tokens}`,
+      message: `tokens: Expected string or array of strings, received ${typeof rawConfig.tokens}`,
     });
   }
   for (let i = 0; i < config.tokens!.length; i++) {
@@ -111,8 +109,7 @@ function normalizeOutDir({ config, cwd, logger }: { config: ConfigInit; logger: 
   } else if (typeof config.outDir !== 'string') {
     logger.error({
       group: 'config',
-      label: 'outDir',
-      message: `Expected string, received ${JSON.stringify(config.outDir)}`,
+      message: `outDir: Expected string, received ${JSON.stringify(config.outDir)}`,
     });
   } else {
     config.outDir = new URL(config.outDir, cwd);
@@ -130,8 +127,7 @@ function normalizePlugins({ config, logger }: { config: ConfigInit; logger: Logg
   if (!Array.isArray(config.plugins)) {
     logger.error({
       group: 'config',
-      label: 'plugins',
-      message: `Expected array of plugins, received ${JSON.stringify(config.plugins)}`,
+      message: `plugins: Expected array of plugins, received ${JSON.stringify(config.plugins)}`,
     });
   }
   config.plugins.push(coreLintPlugin());
@@ -140,8 +136,7 @@ function normalizePlugins({ config, logger }: { config: ConfigInit; logger: Logg
     if (typeof plugin !== 'object') {
       logger.error({
         group: 'config',
-        label: `plugin[${n}]`,
-        message: `Expected output plugin, received ${JSON.stringify(plugin)}`,
+        message: `plugin#${n}: Expected output plugin, received ${JSON.stringify(plugin)}`,
       });
     } else if (!plugin.name) {
       logger.error({ group: 'config', label: `plugin[${n}]`, message: `Missing "name"` });
@@ -170,8 +165,7 @@ function normalizeLint({ config, logger }: { config: ConfigInit; logger: Logger 
       if (typeof config.lint.build.enabled !== 'boolean') {
         logger.error({
           group: 'config',
-          label: 'lint › build › enabled',
-          message: `Expected boolean, received ${JSON.stringify(config.lint.build)}`,
+          message: `lint.build.enabled: Expected boolean, received ${JSON.stringify(config.lint.build)}`,
         });
       }
     } else {
@@ -184,8 +178,7 @@ function normalizeLint({ config, logger }: { config: ConfigInit; logger: Logger 
       if (config.lint.rules === null || typeof config.lint.rules !== 'object' || Array.isArray(config.lint.rules)) {
         logger.error({
           group: 'config',
-          label: 'lint › rules',
-          message: `Expected object, received ${JSON.stringify(config.lint.rules)}`,
+          message: `lint.rules: Expected object, received ${JSON.stringify(config.lint.rules)}`,
         });
         return;
       }
@@ -199,8 +192,7 @@ function normalizeLint({ config, logger }: { config: ConfigInit; logger: Logger 
         if (!pluginRules || Array.isArray(pluginRules) || typeof pluginRules !== 'object') {
           logger.error({
             group: 'config',
-            label: `plugin › ${plugin.name}`,
-            message: `Expected object for lint() received ${JSON.stringify(pluginRules)}`,
+            message: `${plugin.name}: Expected object for lint() received ${JSON.stringify(pluginRules)}`,
           });
           continue;
         }
@@ -211,8 +203,7 @@ function normalizeLint({ config, logger }: { config: ConfigInit; logger: Logger 
           if (allRules.get(rule) && allRules.get(rule) !== plugin.name) {
             logger.error({
               group: 'config',
-              label: `plugin › ${plugin.name}`,
-              message: `Duplicate rule ${rule} already registered by plugin ${allRules.get(rule)}`,
+              message: `${plugin.name}: Duplicate rule ${rule} already registered by plugin ${allRules.get(rule)}`,
             });
           }
           allRules.set(rule, plugin.name);
@@ -223,8 +214,7 @@ function normalizeLint({ config, logger }: { config: ConfigInit; logger: Logger 
         if (!allRules.has(id)) {
           logger.error({
             group: 'config',
-            label: `lint › rule › ${id}`,
-            message: 'Unknown rule. Is the plugin installed?',
+            message: `lint.rules.${id}: Unknown rule. Is the plugin installed?`,
           });
         }
 
@@ -239,8 +229,7 @@ function normalizeLint({ config, logger }: { config: ConfigInit; logger: Logger 
         } else if (value !== undefined) {
           logger.error({
             group: 'config',
-            label: `lint › rule › ${id}`,
-            message: `Invalid eyntax. Expected \`string | number | Array\`, received ${JSON.stringify(value)}}`,
+            message: `lint.rules.${id}: Invalid syntax. Expected \`string | number | Array\`, received ${JSON.stringify(value)}}`,
           });
         }
         config.lint.rules[id] = [severity, options];
@@ -248,8 +237,7 @@ function normalizeLint({ config, logger }: { config: ConfigInit; logger: Logger 
           if (severity !== 0 && severity !== 1 && severity !== 2) {
             logger.error({
               group: 'config',
-              label: `lint › rule › ${id}`,
-              message: `Invalid number ${severity}. Specify 0 (off), 1 (warn), or 2 (error).`,
+              message: `lint.rules.${id}: Invalid number ${severity}. Specify 0 (off), 1 (warn), or 2 (error).`,
             });
           }
           config.lint.rules[id]![0] = (['off', 'warn', 'error'] as const)[severity]!;
@@ -257,15 +245,13 @@ function normalizeLint({ config, logger }: { config: ConfigInit; logger: Logger 
           if (severity !== 'off' && severity !== 'warn' && severity !== 'error') {
             logger.error({
               group: 'config',
-              label: `lint › rule › ${id}`,
-              message: `Invalid string ${JSON.stringify(severity)}. Specify "off", "warn", or "error".`,
+              message: `lint.rules.${id}: Invalid string ${JSON.stringify(severity)}. Specify "off", "warn", or "error".`,
             });
           }
         } else if (value !== null) {
           logger.error({
             group: 'config',
-            label: `lint › rule › ${id}`,
-            message: `Expected string or number, received ${JSON.stringify(value)}`,
+            message: `lint.rules.${id}: Expected string or number, received ${JSON.stringify(value)}`,
           });
         }
       }
@@ -287,15 +273,13 @@ function normalizeIgnore({ config, logger }: { config: ConfigInit; logger: Logge
   if (!Array.isArray(config.ignore.tokens) || config.ignore.tokens.some((x) => typeof x !== 'string')) {
     logger.error({
       group: 'config',
-      label: 'ignore › tokens',
-      message: `Expected array of strings, received ${JSON.stringify(config.ignore.tokens)}`,
+      message: `ignore.tokens: Expected array of strings, received ${JSON.stringify(config.ignore.tokens)}`,
     });
   }
   if (typeof config.ignore.deprecated !== 'boolean') {
     logger.error({
       group: 'config',
-      label: 'ignore › deprecated',
-      message: `Expected boolean, received ${JSON.stringify(config.ignore.deprecated)}`,
+      message: `ignore.deprecated: Expected boolean, received ${JSON.stringify(config.ignore.deprecated)}`,
     });
   }
 }

--- a/packages/parser/src/logger.ts
+++ b/packages/parser/src/logger.ts
@@ -6,7 +6,7 @@ import { codeFrameColumns } from './lib/code-frame.js';
 export const LOG_ORDER = ['error', 'warn', 'info', 'debug'] as const;
 export type LogSeverity = 'error' | 'warn' | 'info' | 'debug';
 export type LogLevel = LogSeverity | 'silent';
-export type LogGroup = 'config' | 'parser' | 'resolver' | 'lint' | 'plugin' | 'server';
+export type LogGroup = 'config' | 'import' | 'lint' | 'parser' | 'plugin' | 'resolver' | 'server';
 
 export interface LogEntry {
   /** Originator of log message */
@@ -42,7 +42,22 @@ export interface DebugEntry {
   timing?: number;
 }
 
-const MESSAGE_COLOR: Record<string, typeof pc.red | undefined> = { error: pc.red, warn: pc.yellow };
+const GROUP_COLOR = {
+  config: pc.cyan,
+  import: pc.green,
+  lint: pc.yellowBright,
+  parser: pc.magenta,
+  plugin: pc.greenBright,
+  resolver: pc.magentaBright,
+  server: pc.gray,
+};
+
+const MESSAGE_COLOR = {
+  error: pc.red,
+  warn: pc.yellow,
+  info: (msg: string) => msg,
+  debug: pc.gray,
+};
 
 const timeFormatter = new Intl.DateTimeFormat('en-us', {
   hour: 'numeric',
@@ -58,11 +73,10 @@ const timeFormatter = new Intl.DateTimeFormat('en-us', {
  * @return {string}
  */
 export function formatMessage(entry: LogEntry, severity: LogSeverity) {
+  const groupColor = GROUP_COLOR[entry.group];
+  const messageColor = MESSAGE_COLOR[severity];
   let message = entry.message;
-  message = `[${entry.group}${entry.label ? `:${entry.label}` : ''}] ${message}`;
-  if (severity in MESSAGE_COLOR) {
-    message = MESSAGE_COLOR[severity]!(message);
-  }
+  message = `${groupColor(`${entry.group}${entry.label ? `:${entry.label}` : ''}:`)} ${messageColor(message)}`;
   if (typeof entry.timing === 'number') {
     message = `${message} ${formatTiming(entry.timing)}`;
   }

--- a/packages/parser/test/alias.test.ts
+++ b/packages/parser/test/alias.test.ts
@@ -766,7 +766,7 @@ font:
           },
         ],
         want: {
-          error: `[parser:init] Could not resolve alias {color.base.blue.600}.
+          error: `parser:init: Could not resolve alias {color.base.blue.600}.
 
   17 |     },
   18 |     "semantic": {
@@ -798,7 +798,7 @@ font:
           },
         ],
         want: {
-          error: `[parser:init] Could not resolve alias {color.base.blue.600}.
+          error: `parser:init: Could not resolve alias {color.base.blue.600}.
 
   1 | {
   2 |   "semantic": {
@@ -819,7 +819,7 @@ font:
           },
         ],
         want: {
-          error: `[parser:init] Invalid alias syntax.
+          error: `parser:init: Invalid alias syntax.
 
   1 | {
   2 |   "alias": {
@@ -846,7 +846,7 @@ font:
           },
         ],
         want: {
-          error: `[parser:init] Circular alias detected.
+          error: `parser:init: Circular alias detected.
 
   3 |     "$type": "color",
   4 |     "primary": {
@@ -878,7 +878,7 @@ font:
           },
         ],
         want: {
-          error: `[parser:init] Cannot alias to $type "dimension" from $type "border".
+          error: `parser:init: Cannot alias to $type "dimension" from $type "border".
 
   12 |     "base": {
   13 |       "$type": "border",
@@ -904,7 +904,7 @@ font:
           },
         ],
         want: {
-          error: `[parser:init] Cannot alias to $type "number" from $type "color".
+          error: `parser:init: Cannot alias to $type "number" from $type "color".
 
    7 |     "base": {
    8 |       "$type": "color",
@@ -951,7 +951,7 @@ font:
           },
         ],
         want: {
-          error: `[parser:init] Cannot alias to $type "color" from $type "dimension".
+          error: `parser:init: Cannot alias to $type "color" from $type "dimension".
 
   25 |       "$value": {
   26 |         "color": "{color.blue}",
@@ -1001,7 +1001,7 @@ font:
           },
         ],
         want: {
-          error: `[parser:init] Cannot alias to $type "duration" from $type "number".
+          error: `parser:init: Cannot alias to $type "duration" from $type "number".
 
   39 |         {
   40 |           "color": "{color.blue}",
@@ -1030,7 +1030,7 @@ font:
           },
         ],
         want: {
-          error: `[parser:init] Cannot alias to $type "number" from $type "dimension".
+          error: `parser:init: Cannot alias to $type "number" from $type "dimension".
 
   21 |         "dashArray": [
   22 |           "{dimension.s}",

--- a/packages/parser/test/border.test.ts
+++ b/packages/parser/test/border.test.ts
@@ -44,7 +44,7 @@ describe('9.3 Border', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-border] Border token missing required properties: color, width, and style.
+          error: `lint:core/valid-border: Border token missing required properties: color, width, and style.
 
   2 |   "border": {
   3 |     "$type": "border",
@@ -54,7 +54,7 @@ describe('9.3 Border', () => {
   6 |       "width": {
   7 |         "value": 1,
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -78,7 +78,7 @@ describe('9.3 Border', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-border] Unknown property: "bad".
+          error: `lint:core/valid-border: Unknown property: "bad".
 
   17 |         "unit": "px"
   18 |       },
@@ -88,7 +88,7 @@ describe('9.3 Border', () => {
   21 |   }
   22 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],

--- a/packages/parser/test/color.test.ts
+++ b/packages/parser/test/color.test.ts
@@ -54,7 +54,7 @@ describe('8.1 Color', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-color] Migrate to the new object format, e.g. "#ff0000" → { "colorSpace": "srgb", "components": [1, 0, 0] } }
+          error: `lint:core/valid-color: Migrate to the new object format, e.g. "#ff0000" → { "colorSpace": "srgb", "components": [1, 0, 0] } }
 
   3 |     "cobalt": {
   4 |       "$type": "color",
@@ -64,7 +64,7 @@ describe('8.1 Color', () => {
   7 |   }
   8 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -78,7 +78,7 @@ describe('8.1 Color', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-color] Expected components to be array of numbers, received undefined.
+          error: `lint:core/valid-color: Expected components to be array of numbers, received undefined.
 
   3 |     "cobalt": {
   4 |       "$type": "color",
@@ -88,7 +88,7 @@ describe('8.1 Color', () => {
   7 |         "channels": [
   8 |           0.3,
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -102,7 +102,7 @@ describe('8.1 Color', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-color] Could not parse color "".
+          error: `lint:core/valid-color: Could not parse color "".
 
   2 |   "color": {
   3 |     "$type": "color",
@@ -111,7 +111,7 @@ describe('8.1 Color', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -125,7 +125,7 @@ describe('8.1 Color', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-color] Could not parse color 0.
+          error: `lint:core/valid-color: Could not parse color 0.
 
   2 |   "color": {
   3 |     "$type": "color",
@@ -134,7 +134,7 @@ describe('8.1 Color', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -148,7 +148,7 @@ describe('8.1 Color', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-color] Invalid color space: undefined. Expected a98-rgb, display-p3, hsl, hwb, lab, lab-d65, lch, okhsv, oklab, oklch, prophoto-rgb, rec2020, srgb, srgb-linear, xyz, xyz-d50, or xyz-d65.
+          error: `lint:core/valid-color: Invalid color space: undefined. Expected a98-rgb, display-p3, hsl, hwb, lab, lab-d65, lch, okhsv, oklab, oklch, prophoto-rgb, rec2020, srgb, srgb-linear, xyz, xyz-d50, or xyz-d65.
 
   3 |     "cobalt": {
   4 |       "$type": "color",
@@ -158,7 +158,7 @@ describe('8.1 Color', () => {
   7 |           0.3,
   8 |           0.6,
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -172,7 +172,7 @@ describe('8.1 Color', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-color] Expected components to be array of numbers, received undefined.
+          error: `lint:core/valid-color: Expected components to be array of numbers, received undefined.
 
   3 |     "cobalt": {
   4 |       "$type": "color",
@@ -182,7 +182,7 @@ describe('8.1 Color', () => {
   7 |       }
   8 |     }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -207,7 +207,7 @@ describe('8.1 Color', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-color] Expected 3 components, received 4.
+          error: `lint:core/valid-color: Expected 3 components, received 4.
 
    8 |           "$value": {
    9 |             "colorSpace": "srgb",
@@ -217,7 +217,7 @@ describe('8.1 Color', () => {
   12 |               0.6,
   13 |               1,
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -233,7 +233,7 @@ describe('8.1 Color', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-color] Invalid color space: mondrian. Expected a98-rgb, display-p3, hsl, hwb, lab, lab-d65, lch, okhsv, oklab, oklch, prophoto-rgb, rec2020, srgb, srgb-linear, xyz, xyz-d50, or xyz-d65.
+          error: `lint:core/valid-color: Invalid color space: mondrian. Expected a98-rgb, display-p3, hsl, hwb, lab, lab-d65, lch, okhsv, oklab, oklch, prophoto-rgb, rec2020, srgb, srgb-linear, xyz, xyz-d50, or xyz-d65.
 
   4 |       "$type": "color",
   5 |       "$value": {
@@ -243,7 +243,7 @@ describe('8.1 Color', () => {
   8 |           0.3,
   9 |           0.6,
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -261,7 +261,7 @@ describe('8.1 Color', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-color] Alpha quack not in range 0 – 1.
+          error: `lint:core/valid-color: Alpha quack not in range 0 – 1.
 
   10 |           1
   11 |         ],
@@ -271,7 +271,7 @@ describe('8.1 Color', () => {
   14 |     }
   15 |   }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -289,7 +289,7 @@ describe('8.1 Color', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-color] Could not parse color #abcde.
+          error: `lint:core/valid-color: Could not parse color #abcde.
 
    5 |       "$value": {
    6 |         "colorSpace": "srgb",
@@ -299,7 +299,7 @@ describe('8.1 Color', () => {
    9 |           0.3,
   10 |           0.6,
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -317,7 +317,7 @@ describe('8.1 Color', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-color] Unknown property "bad".
+          error: `lint:core/valid-color: Unknown property "bad".
 
   10 |           1
   11 |         ],
@@ -327,7 +327,7 @@ describe('8.1 Color', () => {
   14 |     }
   15 |   }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],

--- a/packages/parser/test/config.test.ts
+++ b/packages/parser/test/config.test.ts
@@ -10,21 +10,21 @@ describe('config', () => {
         'tokens: URL',
         {
           given: { tokens: new URL('https://google.com') },
-          want: '[config:tokens] Expected string or array of strings, received object',
+          want: 'config: tokens: Expected string or array of strings, received object',
         },
       ],
       [
         'outDir: null',
         {
           given: { outDir: null },
-          want: '[config:outDir] Expected string, received null',
+          want: 'config: outDir: Expected string, received null',
         },
       ],
       [
         'plugins: not array',
         {
           given: { plugins: {} },
-          want: '[config:plugins] Expected array of plugins, received {}',
+          want: 'config: plugins: Expected array of plugins, received {}',
         },
       ],
       [
@@ -45,7 +45,7 @@ describe('config', () => {
               },
             },
           },
-          want: '[config:lint › rule › foo-bar] Invalid number 42. Specify 0 (off), 1 (warn), or 2 (error).',
+          want: 'config: lint.rules.foo-bar: Invalid number 42. Specify 0 (off), 1 (warn), or 2 (error).',
         },
       ],
       [
@@ -66,7 +66,7 @@ describe('config', () => {
               },
             },
           },
-          want: '[config:lint › rule › foo-bar] Invalid string "feebee". Specify "off", "warn", or "error".',
+          want: 'config: lint.rules.foo-bar: Invalid string "feebee". Specify "off", "warn", or "error".',
         },
       ],
       [
@@ -77,7 +77,7 @@ describe('config', () => {
               rules: { 'foo-bar': 'error' },
             },
           },
-          want: '[config:lint › rule › foo-bar] Unknown rule. Is the plugin installed?',
+          want: 'config: lint.rules.foo-bar: Unknown rule. Is the plugin installed?',
         },
       ],
     ];

--- a/packages/parser/test/cubic-bezier.test.ts
+++ b/packages/parser/test/cubic-bezier.test.ts
@@ -50,7 +50,7 @@ describe('8.6 Cubic Bézier', () => {
           { filename: DEFAULT_FILENAME, src: { cubic: { $type: 'cubicBezier', $value: [0.33, 1, 0.68, 1, 5] } } },
         ],
         want: {
-          error: `[lint:core/valid-cubic-bezier] Expected [number, number, number, number].
+          error: `lint:core/valid-cubic-bezier: Expected [number, number, number, number].
 
   2 |   "cubic": {
   3 |     "$type": "cubicBezier",
@@ -60,7 +60,7 @@ describe('8.6 Cubic Bézier', () => {
   6 |       1,
   7 |       0.68,
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -74,7 +74,7 @@ describe('8.6 Cubic Bézier', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-cubic-bezier] x values must be between 0-1.
+          error: `lint:core/valid-cubic-bezier: x values must be between 0-1.
 
   3 |     "$type": "cubicBezier",
   4 |     "$value": [
@@ -84,7 +84,7 @@ describe('8.6 Cubic Bézier', () => {
   7 |       "68%",
   8 |       "100%"
 
-[lint:core/valid-cubic-bezier] x values must be between 0-1.
+lint:core/valid-cubic-bezier: x values must be between 0-1.
 
    5 |       "33%",
    6 |       "100%",
@@ -94,7 +94,7 @@ describe('8.6 Cubic Bézier', () => {
    9 |     ]
   10 |   }
 
-[lint:core/valid-cubic-bezier] y values must be a valid number.
+lint:core/valid-cubic-bezier: y values must be a valid number.
 
   4 |     "$value": [
   5 |       "33%",
@@ -104,7 +104,7 @@ describe('8.6 Cubic Bézier', () => {
   8 |       "100%"
   9 |     ]
 
-[lint:core/valid-cubic-bezier] y values must be a valid number.
+lint:core/valid-cubic-bezier: y values must be a valid number.
 
    6 |       "100%",
    7 |       "68%",
@@ -114,7 +114,7 @@ describe('8.6 Cubic Bézier', () => {
   10 |   }
   11 | }
 
-[lint:lint] 4 errors`,
+lint:lint: 4 errors`,
         },
       },
     ],

--- a/packages/parser/test/dimension.test.ts
+++ b/packages/parser/test/dimension.test.ts
@@ -45,7 +45,7 @@ describe('8.2 Dimension', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { xs: { $type: 'dimension', $value: '0.5rem' } } }],
         want: {
-          error: `[lint:core/valid-dimension] Migrate to the new object format: { "value": 10, "unit": "px" }.
+          error: `lint:core/valid-dimension: Migrate to the new object format: { "value": 10, "unit": "px" }.
 
   2 |   "xs": {
   3 |     "$type": "dimension",
@@ -54,7 +54,7 @@ describe('8.2 Dimension', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -63,7 +63,7 @@ describe('8.2 Dimension', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { xs: { $type: 'dimension', $value: '' } } }],
         want: {
-          error: `[lint:core/valid-dimension] Migrate to the new object format: { "value": 10, "unit": "px" }.
+          error: `lint:core/valid-dimension: Migrate to the new object format: { "value": 10, "unit": "px" }.
 
   2 |   "xs": {
   3 |     "$type": "dimension",
@@ -72,7 +72,7 @@ describe('8.2 Dimension', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -81,7 +81,7 @@ describe('8.2 Dimension', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { xs: { $type: 'dimension', $value: 'rem' } } }],
         want: {
-          error: `[lint:core/valid-dimension] Migrate to the new object format: { "value": 10, "unit": "px" }.
+          error: `lint:core/valid-dimension: Migrate to the new object format: { "value": 10, "unit": "px" }.
 
   2 |   "xs": {
   3 |     "$type": "dimension",
@@ -90,7 +90,7 @@ describe('8.2 Dimension', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -99,7 +99,7 @@ describe('8.2 Dimension', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { xs: { $type: 'dimension', $value: '16' } } }],
         want: {
-          error: `[lint:core/valid-dimension] Migrate to the new object format: { "value": 10, "unit": "px" }.
+          error: `lint:core/valid-dimension: Migrate to the new object format: { "value": 10, "unit": "px" }.
 
   2 |   "xs": {
   3 |     "$type": "dimension",
@@ -108,7 +108,7 @@ describe('8.2 Dimension', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -117,7 +117,7 @@ describe('8.2 Dimension', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { xs: { $type: 'dimension', $value: 42 } } }],
         want: {
-          error: `[lint:core/valid-dimension] Invalid dimension: 42. Expected object with "value" and "unit".
+          error: `lint:core/valid-dimension: Invalid dimension: 42. Expected object with "value" and "unit".
 
   2 |   "xs": {
   3 |     "$type": "dimension",
@@ -126,7 +126,7 @@ describe('8.2 Dimension', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -135,7 +135,7 @@ describe('8.2 Dimension', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { xs: { $type: 'dimension', $value: 0 } } }],
         want: {
-          error: `[lint:core/valid-dimension] Invalid dimension: 0. Expected object with "value" and "unit".
+          error: `lint:core/valid-dimension: Invalid dimension: 0. Expected object with "value" and "unit".
 
   2 |   "xs": {
   3 |     "$type": "dimension",
@@ -144,7 +144,7 @@ describe('8.2 Dimension', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -153,7 +153,7 @@ describe('8.2 Dimension', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { md: { $type: 'dimension', $value: { value: 1, unit: 'vw' } } } }],
         want: {
-          error: `[lint:core/valid-dimension] Unit vw not allowed. Expected px, em, or rem.
+          error: `lint:core/valid-dimension: Unit vw not allowed. Expected px, em, or rem.
 
   4 |     "$value": {
   5 |       "value": 1,
@@ -163,7 +163,7 @@ describe('8.2 Dimension', () => {
   8 |   }
   9 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -177,7 +177,7 @@ describe('8.2 Dimension', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-dimension] Unknown property "bad".
+          error: `lint:core/valid-dimension: Unknown property "bad".
 
    5 |       "value": 2,
    6 |       "unit": "px",
@@ -187,7 +187,7 @@ describe('8.2 Dimension', () => {
    9 |   }
   10 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],

--- a/packages/parser/test/duration.test.ts
+++ b/packages/parser/test/duration.test.ts
@@ -45,7 +45,7 @@ describe('8.5 Duration', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { quick: { $type: 'duration', $value: '100ms' } } }],
         want: {
-          error: `[lint:core/valid-duration] Migrate to the new object format: { "value": 2, "unit": "ms" }.
+          error: `lint:core/valid-duration: Migrate to the new object format: { "value": 2, "unit": "ms" }.
 
   2 |   "quick": {
   3 |     "$type": "duration",
@@ -54,7 +54,7 @@ describe('8.5 Duration', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -63,7 +63,7 @@ describe('8.5 Duration', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { moderate: { $type: 'duration', $value: '' } } }],
         want: {
-          error: `[lint:core/valid-duration] Migrate to the new object format: { "value": 2, "unit": "ms" }.
+          error: `lint:core/valid-duration: Migrate to the new object format: { "value": 2, "unit": "ms" }.
 
   2 |   "moderate": {
   3 |     "$type": "duration",
@@ -72,7 +72,7 @@ describe('8.5 Duration', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -81,7 +81,7 @@ describe('8.5 Duration', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { moderate: { $type: 'duration', $value: 'ms' } } }],
         want: {
-          error: `[lint:core/valid-duration] Migrate to the new object format: { "value": 2, "unit": "ms" }.
+          error: `lint:core/valid-duration: Migrate to the new object format: { "value": 2, "unit": "ms" }.
 
   2 |   "moderate": {
   3 |     "$type": "duration",
@@ -90,7 +90,7 @@ describe('8.5 Duration', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -99,7 +99,7 @@ describe('8.5 Duration', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { moderate: { $type: 'duration', $value: '250' } } }],
         want: {
-          error: `[lint:core/valid-duration] Migrate to the new object format: { "value": 2, "unit": "ms" }.
+          error: `lint:core/valid-duration: Migrate to the new object format: { "value": 2, "unit": "ms" }.
 
   2 |   "moderate": {
   3 |     "$type": "duration",
@@ -108,7 +108,7 @@ describe('8.5 Duration', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -117,7 +117,7 @@ describe('8.5 Duration', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { moderate: { $type: 'duration', $value: 250 } } }],
         want: {
-          error: `[lint:core/valid-duration] Migrate to the new object format: { "value": 2, "unit": "ms" }.
+          error: `lint:core/valid-duration: Migrate to the new object format: { "value": 2, "unit": "ms" }.
 
   2 |   "moderate": {
   3 |     "$type": "duration",
@@ -126,7 +126,7 @@ describe('8.5 Duration', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -140,7 +140,7 @@ describe('8.5 Duration', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-duration] Unknown unit ns. Expected "ms" or "s".
+          error: `lint:core/valid-duration: Unknown unit ns. Expected "ms" or "s".
 
   4 |     "$value": {
   5 |       "value": 200,
@@ -150,7 +150,7 @@ describe('8.5 Duration', () => {
   8 |   }
   9 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -164,7 +164,7 @@ describe('8.5 Duration', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-duration] Unknown property: "bad".
+          error: `lint:core/valid-duration: Unknown property: "bad".
 
    5 |       "value": 100,
    6 |       "unit": "ms",
@@ -174,7 +174,7 @@ describe('8.5 Duration', () => {
    9 |   }
   10 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],

--- a/packages/parser/test/extends.test.ts
+++ b/packages/parser/test/extends.test.ts
@@ -54,7 +54,7 @@ describe('$extends', () => {
           },
         ],
         want: {
-          error: `[parser:init] $extends must be a valid alias
+          error: `parser:init: $extends must be a valid alias
 
   1 | {
   2 |   "color": {
@@ -84,7 +84,7 @@ describe('$extends', () => {
           },
         ],
         want: {
-          error: `[parser:init] $extends can’t exist within a token
+          error: `parser:init: $extends can’t exist within a token
 
   13 |     },
   14 |     "red": {
@@ -111,7 +111,7 @@ describe('$extends', () => {
           },
         ],
         want: {
-          error: `[parser:init] Circular $extends detected
+          error: `parser:init: Circular $extends detected
 
   13 |     },
   14 |     "secondary": {
@@ -136,7 +136,7 @@ describe('$extends', () => {
           },
         ],
         want: {
-          error: `[parser:init] Circular $extends detected
+          error: `parser:init: Circular $extends detected
 
   1 | {
   2 |   "groupA": {

--- a/packages/parser/test/extensions.test.ts
+++ b/packages/parser/test/extensions.test.ts
@@ -22,7 +22,7 @@ describe('8.? Boolean', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { 'my-bool': { $type: 'boolean', $value: 'true' } } }],
         want: {
-          error: `[lint:core/valid-boolean] Must be a boolean.
+          error: `lint:core/valid-boolean: Must be a boolean.
 
   2 |   "my-bool": {
   3 |     "$type": "boolean",
@@ -31,7 +31,7 @@ describe('8.? Boolean', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -40,7 +40,7 @@ describe('8.? Boolean', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { 'my-bool': { $type: 'boolean', $value: 0 } } }],
         want: {
-          error: `[lint:core/valid-boolean] Must be a boolean.
+          error: `lint:core/valid-boolean: Must be a boolean.
 
   2 |   "my-bool": {
   3 |     "$type": "boolean",
@@ -49,7 +49,7 @@ describe('8.? Boolean', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -74,7 +74,7 @@ describe('8.? Link', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { icon: { star: { $type: 'link', $value: '' } } } }],
         want: {
-          error: `[lint:core/valid-link] Must be a string.
+          error: `lint:core/valid-link: Must be a string.
 
   3 |     "star": {
   4 |       "$type": "link",
@@ -84,7 +84,7 @@ describe('8.? Link', () => {
   7 |   }
   8 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -93,7 +93,7 @@ describe('8.? Link', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { icon: { star: { $type: 'link', $value: 100 } } } }],
         want: {
-          error: `[lint:core/valid-link] Must be a string.
+          error: `lint:core/valid-link: Must be a string.
 
   3 |     "star": {
   4 |       "$type": "link",
@@ -103,7 +103,7 @@ describe('8.? Link', () => {
   7 |   }
   8 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -133,7 +133,7 @@ describe('8.? String', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { 'my-string': { $type: 'string', $value: 99 } } }],
         want: {
-          error: `[lint:core/valid-string] Must be a string.
+          error: `lint:core/valid-string: Must be a string.
 
   2 |   "my-string": {
   3 |     "$type": "string",
@@ -142,7 +142,7 @@ describe('8.? String', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],

--- a/packages/parser/test/font-family.test.ts
+++ b/packages/parser/test/font-family.test.ts
@@ -27,7 +27,7 @@ describe('8.3 Font Family', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { base: { $type: 'fontFamily', $value: '' } } }],
         want: {
-          error: `[lint:core/valid-font-family] Must be a string, or array of strings.
+          error: `lint:core/valid-font-family: Must be a string, or array of strings.
 
   2 |   "base": {
   3 |     "$type": "fontFamily",
@@ -36,7 +36,7 @@ describe('8.3 Font Family', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -45,7 +45,7 @@ describe('8.3 Font Family', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { base: { $type: 'fontFamily', $value: [''] } } }],
         want: {
-          error: `[lint:core/valid-font-family] Must be a string, or array of strings.
+          error: `lint:core/valid-font-family: Must be a string, or array of strings.
 
   2 |   "base": {
   3 |     "$type": "fontFamily",
@@ -55,7 +55,7 @@ describe('8.3 Font Family', () => {
   6 |     ]
   7 |   }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -64,7 +64,7 @@ describe('8.3 Font Family', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { base: { $type: 'fontFamily', $value: 200 } } }],
         want: {
-          error: `[lint:core/valid-font-family] Must be a string, or array of strings.
+          error: `lint:core/valid-font-family: Must be a string, or array of strings.
 
   2 |   "base": {
   3 |     "$type": "fontFamily",
@@ -73,7 +73,7 @@ describe('8.3 Font Family', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],

--- a/packages/parser/test/font-weight.test.ts
+++ b/packages/parser/test/font-weight.test.ts
@@ -70,7 +70,7 @@ describe('8.4 Font Weight', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { thinnish: { $type: 'fontWeight', $value: 'thinnish' } } }],
         want: {
-          error: `[lint:core/valid-font-weight] Must either be a valid number (0 - 999) or a valid font weight: thin, hairline, extra-light, ultra-light, light, normal, regular, book, medium, semi-bold, demi-bold, bold, extra-bold, ultra-bold, black, heavy, extra-black, or ultra-black.
+          error: `lint:core/valid-font-weight: Must either be a valid number (0 - 999) or a valid font weight: thin, hairline, extra-light, ultra-light, light, normal, regular, book, medium, semi-bold, demi-bold, bold, extra-bold, ultra-bold, black, heavy, extra-black, or ultra-black.
 
   2 |   "thinnish": {
   3 |     "$type": "fontWeight",
@@ -79,7 +79,7 @@ describe('8.4 Font Weight', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -88,7 +88,7 @@ describe('8.4 Font Weight', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { kakarot: { $type: 'fontWeight', $value: 9001 } } }],
         want: {
-          error: `[lint:core/valid-font-weight] Must either be a valid number (0 - 999) or a valid font weight: thin, hairline, extra-light, ultra-light, light, normal, regular, book, medium, semi-bold, demi-bold, bold, extra-bold, ultra-bold, black, heavy, extra-black, or ultra-black.
+          error: `lint:core/valid-font-weight: Must either be a valid number (0 - 999) or a valid font weight: thin, hairline, extra-light, ultra-light, light, normal, regular, book, medium, semi-bold, demi-bold, bold, extra-bold, ultra-bold, black, heavy, extra-black, or ultra-black.
 
   2 |   "kakarot": {
   3 |     "$type": "fontWeight",
@@ -97,7 +97,7 @@ describe('8.4 Font Weight', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],

--- a/packages/parser/test/gradient.test.ts
+++ b/packages/parser/test/gradient.test.ts
@@ -50,7 +50,7 @@ describe('9.6 Gradient', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-color] Invalid color space: mud. Expected a98-rgb, display-p3, hsl, hwb, lab, lab-d65, lch, okhsv, oklab, oklch, prophoto-rgb, rec2020, srgb, srgb-linear, xyz, xyz-d50, or xyz-d65.
+          error: `lint:core/valid-color: Invalid color space: mud. Expected a98-rgb, display-p3, hsl, hwb, lab, lab-d65, lch, okhsv, oklab, oklch, prophoto-rgb, rec2020, srgb, srgb-linear, xyz, xyz-d50, or xyz-d65.
 
    5 |       {
    6 |         "color": {
@@ -60,7 +60,7 @@ describe('9.6 Gradient', () => {
    9 |         "position": 0
   10 |       },
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -85,7 +85,7 @@ describe('9.6 Gradient', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-gradient] Expected number 0-1, received 12px.
+          error: `lint:core/valid-gradient: Expected number 0-1, received 12px.
 
   27 |           "hex": "#ff9900"
   28 |         },
@@ -95,7 +95,7 @@ describe('9.6 Gradient', () => {
   31 |     ]
   32 |   }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -117,7 +117,7 @@ describe('9.6 Gradient', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-gradient] Must be an array of { color, position } objects.
+          error: `lint:core/valid-gradient: Must be an array of { color, position } objects.
 
   16 |         "position": 0
   17 |       },
@@ -127,7 +127,7 @@ describe('9.6 Gradient', () => {
   20 |           "alpha": 1,
   21 |           "components": [
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -152,7 +152,7 @@ describe('9.6 Gradient', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-gradient] Unknown property "bad".
+          error: `lint:core/valid-gradient: Unknown property "bad".
 
   3 |     "$type": "gradient",
   4 |     "$value": [
@@ -162,7 +162,7 @@ describe('9.6 Gradient', () => {
   7 |           "alpha": 1,
   8 |           "components": [
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],

--- a/packages/parser/test/json-refs.test.ts
+++ b/packages/parser/test/json-refs.test.ts
@@ -243,7 +243,7 @@ describe('JSON $refs', () => {
     } catch (err) {
       expect(
         stripAnsi((err as Error).message),
-      ).toMatch(`[parser:init] $ref "#/" can’t recursively embed its parent document
+      ).toMatch(`parser:init: $ref "#/" can’t recursively embed its parent document
 
   2 |   "$ref": "#\\/"
   3 | }`);
@@ -263,7 +263,7 @@ describe('JSON $refs', () => {
       await parse([{ filename: DEFAULT_FILENAME, src }], { config });
       expect(true).toBe(false);
     } catch (err) {
-      expect(stripAnsi((err as Error).message)).toMatch(`[parser:init] Circular $ref detected: "#/color/grey"
+      expect(stripAnsi((err as Error).message)).toMatch(`parser:init: Circular $ref detected: "#/color/grey"
 
   3 |     "$type": "color",
   4 |     "gray": {
@@ -287,7 +287,7 @@ describe('JSON $refs', () => {
       await parse([{ filename: DEFAULT_FILENAME, src }], { config });
       expect(true).toBe(false);
     } catch (err) {
-      expect(stripAnsi((err as Error).message)).toMatch(`[parser:init] Invalid $ref. Expected string.
+      expect(stripAnsi((err as Error).message)).toMatch(`parser:init: Invalid $ref. Expected string.
 
   4 |     "blue": {
   5 |       "100": {

--- a/packages/parser/test/number.test.ts
+++ b/packages/parser/test/number.test.ts
@@ -15,7 +15,7 @@ describe('8.7 Number', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { number: { $type: 'number', $value: '100' } } }],
         want: {
-          error: `[lint:core/valid-number] Must be a number.
+          error: `lint:core/valid-number: Must be a number.
 
   2 |   "number": {
   3 |     "$type": "number",
@@ -24,7 +24,7 @@ describe('8.7 Number', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -38,7 +38,7 @@ describe('8.7 Number', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-cubic-bezier] x values must be between 0-1.
+          error: `lint:core/valid-cubic-bezier: x values must be between 0-1.
 
   3 |     "$type": "cubicBezier",
   4 |     "$value": [
@@ -48,7 +48,7 @@ describe('8.7 Number', () => {
   7 |       "68%",
   8 |       "100%"
 
-[lint:core/valid-cubic-bezier] x values must be between 0-1.
+lint:core/valid-cubic-bezier: x values must be between 0-1.
 
    5 |       "33%",
    6 |       "100%",
@@ -58,7 +58,7 @@ describe('8.7 Number', () => {
    9 |     ]
   10 |   }
 
-[lint:core/valid-cubic-bezier] y values must be a valid number.
+lint:core/valid-cubic-bezier: y values must be a valid number.
 
   4 |     "$value": [
   5 |       "33%",
@@ -68,7 +68,7 @@ describe('8.7 Number', () => {
   8 |       "100%"
   9 |     ]
 
-[lint:core/valid-cubic-bezier] y values must be a valid number.
+lint:core/valid-cubic-bezier: y values must be a valid number.
 
    6 |       "100%",
    7 |       "68%",
@@ -78,7 +78,7 @@ describe('8.7 Number', () => {
   10 |   }
   11 | }
 
-[lint:lint] 4 errors`,
+lint:lint: 4 errors`,
         },
       },
     ],

--- a/packages/parser/test/parse.test.ts
+++ b/packages/parser/test/parse.test.ts
@@ -40,7 +40,7 @@ describe('Additional cases', () => {
       expect(() => result).toThrow;
     } catch (err) {
       expect(stripAnsi((err as Error).message)).toMatchInlineSnapshot(`
-        "[parser:init] Install yaml-to-momoa package to parse YAML, and pass in as option, e.g.:
+        "parser:init: Install yaml-to-momoa package to parse YAML, and pass in as option, e.g.:
 
           import { bundle } from '@terrazzo/json-schema-tools';
           import yamlToMomoa from 'yaml-to-momoa';

--- a/packages/parser/test/resolver.test.ts
+++ b/packages/parser/test/resolver.test.ts
@@ -24,7 +24,7 @@ describe('Resolver module', () => {
             },
           ],
           want: {
-            error: `[parser:init] Resolver must be the only input, found 2 sources.`,
+            error: `parser:init: Resolver must be the only input, found 2 sources.`,
           },
         },
       ],
@@ -64,7 +64,7 @@ describe('Resolver module', () => {
           given: {
             resolutionOrder: [{ $ref: '#/sets/base' }],
           },
-          want: `[parser:resolver] Missing "version".
+          want: `parser:resolver: Missing "version".
 
 > 1 | {
     | ^
@@ -80,7 +80,7 @@ describe('Resolver module', () => {
             version: 1,
             resolutionOrder: [{ $ref: '#/sets/base' }],
           },
-          want: `[parser:resolver] Expected "version" to be "2025.10".
+          want: `parser:resolver: Expected "version" to be "2025.10".
 
   1 | {
 > 2 |   "version": 1,
@@ -105,7 +105,7 @@ describe('Resolver module', () => {
             },
             resolutionOrder: [{ $ref: '#/modifiers/theme' }],
           },
-          want: `[parser:resolver] Expected array.
+          want: `parser:resolver: Expected array.
 
    9 |           }
   10 |         ],
@@ -122,7 +122,7 @@ describe('Resolver module', () => {
           given: {
             version: '2025.10',
           },
-          want: `[parser:resolver] Missing "resolutionOrder".
+          want: `parser:resolver: Missing "resolutionOrder".
 
 > 1 | {
     | ^
@@ -137,7 +137,7 @@ describe('Resolver module', () => {
             version: '2025.10',
             resolutionOrder: { foo: 'bar' },
           },
-          want: `[parser:resolver] Expected array.
+          want: `parser:resolver: Expected array.
 
   1 | {
   2 |   "version": "2025.10",

--- a/packages/parser/test/shadow.test.ts
+++ b/packages/parser/test/shadow.test.ts
@@ -119,7 +119,7 @@ describe('9.5 Shadow', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-dimension] Invalid dimension: 0. Expected object with "value" and "unit".
+          error: `lint:core/valid-dimension: Invalid dimension: 0. Expected object with "value" and "unit".
 
   13 |           "alpha": 0.1
   14 |         },
@@ -129,7 +129,7 @@ describe('9.5 Shadow', () => {
   17 |           "value": 0.25,
   18 |           "unit": "rem"
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -153,7 +153,7 @@ describe('9.5 Shadow', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-shadow] Missing required properties: color, offsetX, offsetY, blur, and spread.
+          error: `lint:core/valid-shadow: Missing required properties: color, offsetX, offsetY, blur, and spread.
 
   2 |   "shadow-base": {
   3 |     "$type": "shadow",
@@ -163,7 +163,7 @@ describe('9.5 Shadow', () => {
   6 |         "value": 0,
   7 |         "unit": "rem"
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -231,7 +231,7 @@ describe('9.5 Shadow', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-shadow] Unknown property "bad".
+          error: `lint:core/valid-shadow: Unknown property "bad".
 
   30 |         },
   31 |         "inset": false,
@@ -241,7 +241,7 @@ describe('9.5 Shadow', () => {
   34 |     ]
   35 |   }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],

--- a/packages/parser/test/stroke-style.test.ts
+++ b/packages/parser/test/stroke-style.test.ts
@@ -50,7 +50,7 @@ describe('9.2 Stroke Style', () => {
       {
         given: [{ filename: DEFAULT_FILENAME, src: { 'border-style': { $type: 'strokeStyle', $value: 'thicc' } } }],
         want: {
-          error: `[lint:core/valid-stroke-style] Value most be one of solid, dashed, dotted, double, groove, ridge, outset, or inset.
+          error: `lint:core/valid-stroke-style: Value most be one of solid, dashed, dotted, double, groove, ridge, outset, or inset.
 
   2 |   "border-style": {
   3 |     "$type": "strokeStyle",
@@ -59,7 +59,7 @@ describe('9.2 Stroke Style', () => {
   5 |   }
   6 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -78,7 +78,7 @@ describe('9.2 Stroke Style', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-dimension] Migrate to the new object format: { "value": 10, "unit": "px" }.
+          error: `lint:core/valid-dimension: Migrate to the new object format: { "value": 10, "unit": "px" }.
 
    5 |       "lineCap": "round",
    6 |       "dashArray": [
@@ -88,7 +88,7 @@ describe('9.2 Stroke Style', () => {
    9 |       ]
   10 |     }
 
-[lint:core/valid-dimension] Migrate to the new object format: { "value": 10, "unit": "px" }.
+lint:core/valid-dimension: Migrate to the new object format: { "value": 10, "unit": "px" }.
 
    6 |       "dashArray": [
    7 |         "0.25rem",
@@ -98,7 +98,7 @@ describe('9.2 Stroke Style', () => {
   10 |     }
   11 |   }
 
-[lint:lint] 2 errors`,
+lint:lint: 2 errors`,
         },
       },
     ],
@@ -124,7 +124,7 @@ describe('9.2 Stroke Style', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-stroke-style] Unknown property: "bad".
+          error: `lint:core/valid-stroke-style: Unknown property: "bad".
 
   14 |         }
   15 |       ],
@@ -134,7 +134,7 @@ describe('9.2 Stroke Style', () => {
   18 |   }
   19 | }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],

--- a/packages/parser/test/transition.test.ts
+++ b/packages/parser/test/transition.test.ts
@@ -71,7 +71,7 @@ describe('9.4 Transition', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-transition] Missing required properties: duration, delay, and timingFunction.
+          error: `lint:core/valid-transition: Missing required properties: duration, delay, and timingFunction.
 
   3 |     "ease-in-out": {
   4 |       "$type": "transition",
@@ -81,7 +81,7 @@ describe('9.4 Transition', () => {
   7 |           0.42,
   8 |           0,
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -105,7 +105,7 @@ describe('9.4 Transition', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-transition] Missing required properties: duration, delay, and timingFunction.
+          error: `lint:core/valid-transition: Missing required properties: duration, delay, and timingFunction.
 
   3 |     "ease-in-out": {
   4 |       "$type": "transition",
@@ -115,7 +115,7 @@ describe('9.4 Transition', () => {
   7 |           "value": 150,
   8 |           "unit": "ms"
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -139,7 +139,7 @@ describe('9.4 Transition', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-transition] Missing required properties: duration, delay, and timingFunction.
+          error: `lint:core/valid-transition: Missing required properties: duration, delay, and timingFunction.
 
   3 |     "ease-in-out": {
   4 |       "$type": "transition",
@@ -149,7 +149,7 @@ describe('9.4 Transition', () => {
   7 |           "value": 150,
   8 |           "unit": "ms"
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],
@@ -175,7 +175,7 @@ describe('9.4 Transition', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-transition] Unknown property: "bad".
+          error: `lint:core/valid-transition: Unknown property: "bad".
 
   18 |           "unit": "ms"
   19 |         },
@@ -185,7 +185,7 @@ describe('9.4 Transition', () => {
   22 |     }
   23 |   }
 
-[lint:lint] 1 error`,
+lint:lint: 1 error`,
         },
       },
     ],

--- a/packages/parser/test/typography.test.ts
+++ b/packages/parser/test/typography.test.ts
@@ -298,7 +298,7 @@ describe('9.7 Typography', () => {
           },
         ],
         want: {
-          error: `[parser:init] Cannot alias to $type "number" from $type "fontWeight".
+          error: `parser:init: Cannot alias to $type "number" from $type "fontWeight".
 
   19 |         "fontStyle": "italic",
   20 |         "fontVariant": "small-caps",
@@ -320,7 +320,7 @@ describe('9.7 Typography', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-typography] Missing required property "fontFamily".
+          error: `lint:core/valid-typography: Missing required property "fontFamily".
 
   3 |     "body": {
   4 |       "$type": "typography",
@@ -330,7 +330,7 @@ describe('9.7 Typography', () => {
   7 |       }
   8 |     }
 
-[lint:core/valid-typography] Missing required property "fontSize".
+lint:core/valid-typography: Missing required property "fontSize".
 
   3 |     "body": {
   4 |       "$type": "typography",
@@ -340,7 +340,7 @@ describe('9.7 Typography', () => {
   7 |       }
   8 |     }
 
-[lint:core/valid-typography] Missing required property "fontWeight".
+lint:core/valid-typography: Missing required property "fontWeight".
 
   3 |     "body": {
   4 |       "$type": "typography",
@@ -350,7 +350,7 @@ describe('9.7 Typography', () => {
   7 |       }
   8 |     }
 
-[lint:core/valid-typography] Missing required property "letterSpacing".
+lint:core/valid-typography: Missing required property "letterSpacing".
 
   3 |     "body": {
   4 |       "$type": "typography",
@@ -360,7 +360,7 @@ describe('9.7 Typography', () => {
   7 |       }
   8 |     }
 
-[lint:core/valid-typography] Missing required property "lineHeight".
+lint:core/valid-typography: Missing required property "lineHeight".
 
   3 |     "body": {
   4 |       "$type": "typography",
@@ -370,7 +370,7 @@ describe('9.7 Typography', () => {
   7 |       }
   8 |     }
 
-[lint:lint] 5 errors`,
+lint:lint: 5 errors`,
         },
       },
     ],
@@ -395,7 +395,7 @@ describe('9.7 Typography', () => {
           },
         ],
         want: {
-          error: `[lint:core/valid-dimension] Migrate to the new object format: { "value": 10, "unit": "px" }.
+          error: `lint:core/valid-dimension: Migrate to the new object format: { "value": 10, "unit": "px" }.
 
   4 |     "$value": {
   5 |       "fontFamily": "Helvetica",
@@ -405,7 +405,7 @@ describe('9.7 Typography', () => {
   8 |       "letterSpacing": "0.001em",
   9 |       "lineHeight": "24px"
 
-[lint:core/valid-dimension] Migrate to the new object format: { "value": 10, "unit": "px" }.
+lint:core/valid-dimension: Migrate to the new object format: { "value": 10, "unit": "px" }.
 
    7 |       "fontWeight": 400,
    8 |       "letterSpacing": "0.001em",
@@ -415,7 +415,7 @@ describe('9.7 Typography', () => {
   11 |   }
   12 | }
 
-[lint:core/valid-dimension] Migrate to the new object format: { "value": 10, "unit": "px" }.
+lint:core/valid-dimension: Migrate to the new object format: { "value": 10, "unit": "px" }.
 
    6 |       "fontSize": "16px",
    7 |       "fontWeight": 400,
@@ -425,7 +425,7 @@ describe('9.7 Typography', () => {
   10 |     }
   11 |   }
 
-[lint:core/valid-number] Must be a number.
+lint:core/valid-number: Must be a number.
 
    7 |       "fontWeight": 400,
    8 |       "letterSpacing": "0.001em",
@@ -435,7 +435,7 @@ describe('9.7 Typography', () => {
   11 |   }
   12 | }
 
-[lint:lint] 4 errors`,
+lint:lint: 4 errors`,
         },
       },
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,9 @@ importers:
         specifier: 'catalog:'
         version: 0.0.8
     devDependencies:
+      '@figma/rest-api-spec':
+        specifier: ^0.36.0
+        version: 0.36.0
       '@swc/core':
         specifier: 'catalog:'
         version: 1.13.19(@swc/helpers@0.5.17)
@@ -1192,24 +1195,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.3.14':
     resolution: {integrity: sha512-KT67FKfzIw6DNnUNdYlBg+eU24Go3n75GWK6NwU4+yJmDYFe9i/MjiI+U/iEzKvo0g7G7MZqoyrhIYuND2w8QQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.3.14':
     resolution: {integrity: sha512-KQU7EkbBBuHPW3/rAcoiVmhlPtDSGOGRPv9js7qJVpYTzjQmVR+C9Rfcz+ti8YCH+zT1J52tuBybtP4IodjxZQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.3.14':
     resolution: {integrity: sha512-ZsZzQsl9U+wxFrGGS4f6UxREUlgHwmEfu1IrXlgNFrNnd5Th6lIJr8KmSzu/+meSa9f4rzFrbEW9LBBA6ScoMA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.3.14':
     resolution: {integrity: sha512-+IKYkj/pUBbnRf1G1+RlyA3LWiDgra1xpS7H2g4BuOzzRbRB+hmlw0yFsLprHhbbt7jUzbzAbAjK/Pn0FDnh1A==}
@@ -1915,6 +1922,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@figma/rest-api-spec@0.36.0':
+    resolution: {integrity: sha512-OyAjMF3ON2k6aVm61H4MrjSNwJ9Q4w2tYGa6qoUG6tVaNk9eMe/JcCKKYgLPfR9PKfKyoxV/xwn9/HBW3C3bKQ==}
+
   '@floating-ui/core@1.7.4':
     resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
 
@@ -1970,89 +1980,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2507,24 +2533,28 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-Z03/wrqau9Bicfgb3Dbs6SYTHliELk2PM2LpG2nFd+cGupTMF5kanLEcj2vuuJLLhptNyS61rtk7SOZ+lPsTUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-iSXXZsQp08CSilff/DCTFZHSVEpEwdicV3W8idHyrByrcsRDVh9sGC3sev6d8BygSGj3vt8GvUKBPCoyMA4tgQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-qaj+MFudtdCv9xZo9znFvkgoajLdc+vwf0Kz5N44g+LU5XMe+IsACgn3UG7uTRlCCvhMAGXm1XlpEA5bZBrOcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.3':
     resolution: {integrity: sha512-U662UnMETyjT65gFmG9ma+XziENrs7BBnENi/27swZPYagubfHRirXHG2oMl+pEax2WvO7Kb9gHZmMakpYqBHQ==}
@@ -2614,66 +2644,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -2886,6 +2929,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.13.19':
     resolution: {integrity: sha512-M/otFc3/rWWkbF6VgbOXVzUKVoE7MFcphTaStxJp4bwb7oP5slYlxMZN51Dk/OTOfvCDo9pTAFDKNyixbkXMDQ==}
@@ -2898,6 +2942,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.13.19':
     resolution: {integrity: sha512-NoMUKaOJEdouU4tKF88ggdDHFiRRING+gYLxDqnTfm+sUXaizB5OGBRzvSVDYSXQb1SuUuChnXFPFzwTWbt3ZQ==}
@@ -2910,6 +2955,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.13.19':
     resolution: {integrity: sha512-r6krlZwyu8SBaw24QuS1lau2I9q8M+eJV6ITz0rpb6P1Bx0elf9ii5Bhh8ddmIqXXH8kOGSjC/dwcdHbZqAhgw==}
@@ -2922,6 +2968,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.13.19':
     resolution: {integrity: sha512-awcZSIuxyVn0Dw28VjMvgk1qiDJ6CeQwHkZNUjg2UxVlq23zE01NMMp+zkoGFypmLG9gaGmJSzuoqvk/WCQ5tw==}
@@ -7651,6 +7698,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.2':
     optional: true
+
+  '@figma/rest-api-spec@0.36.0': {}
 
   '@floating-ui/core@1.7.4':
     dependencies:

--- a/www/src/pages/docs/2.0/guides/import-from-figma.md
+++ b/www/src/pages/docs/2.0/guides/import-from-figma.md
@@ -1,0 +1,70 @@
+---
+title:: Import from Figma
+layout: ../../../../layouts/docs.astro
+---
+
+# Import from Figma
+
+Figma Variables and Styles translate well to DTCG tokens! This guide will show you how to import Variables and Styles from a Figma file, and save to a `.tokens.json` output.
+
+## Quickstart
+
+To import from Figma, you’ll need:
+
+1. A [personal access token](https://developers.figma.com/docs/rest-api/authentication/#access-tokens) with access to the file(s) you want to load Variables & Styles from
+   - For **Styles**, it needs [`file_content:read`, `team_library_content:read`, and `library_content:read` scopes](https://developers.figma.com/docs/rest-api/scopes/).
+   - For **Variables**, it needs the [`file_variables:read` scope](https://developers.figma.com/docs/rest-api/scopes/).
+2. An Enterprise plan to export Variables (with free accounts, only Styles are importable)
+
+### Personal Access Token
+
+Create your [personal access token](https://developers.figma.com/docs/rest-api/authentication/#access-tokens) from Settings inside Figma, and expose it as a `FIGMA_ACCESS_TOKEN` environment variable. You can do this in multiple ways:
+
+- Locally: run `echo 'export FIGMA_ACCESS_TOKEN="(your token value)"' >> ~/.zshrc` (this is great for testing!)
+- [GitHub Actions](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets): add to secrets
+- [GitLab CI](https://docs.gitlab.com/ci/secrets/): add to secrets
+
+:::warning
+
+**Never** add secrets to code or in `package.json` files!
+
+:::
+
+### Importing
+
+Terrazzo won’t load the tokens direct from the Figma file every time, instead, it will save 1 Figma file to 1 `.tokens.json` file. Import one file at a time with:
+
+```sh
+npx tz import https://www.figma.com/design/xxxxxxxxxxxxxxxxxvxxx/Design-System-Variables --output my-tokens.tokens.json
+```
+
+To load other files, simply run the command again.
+
+:::note
+
+It’s intentional that `tz import` always happens separately from `tz build`. Saving Figma output to a `.tokens.json`, checked into Git, makes things easier to version, easier for adjustments/overrides to be made, and guards against data loss. Terrazzo intentionally doesn’t allow Figma URLs in `tokens` for a smoother experience.
+
+:::
+
+### Libraries
+
+If the Figma file has a [Published Library](https://help.figma.com/hc/en-us/articles/360025508373-Publish-a-library) associated with it, Terrazzo will **pull the Published version.** This means that local, unpublished changes will be ignored. To pull unpublished changes, run:
+
+```sh
+npx tz import [file] --unpublished
+```
+
+If the file has _no library_ associated with it, it will simply grab whatever’s in the file at the time of import.
+
+External Libraries used in an imported file will be ignored. In order to import any Library, **you must import its source file.**
+
+### CLI Flags
+
+You can add all the following flags to `tz import`:
+
+| Name                           | Description                                                                                         |
+| :----------------------------- | :-------------------------------------------------------------------------------------------------- |
+| `--output [file]`, `-o [file]` | File to export. If this is omitted, it will output to stdout.                                       |
+| `--unpublished`                | Pulls unpublished Variables and Styles (by default the most recent Published Library will be used). |
+| `--skip-styles`                | Don’t import Styles from this file.                                                                 |
+| `--skip-variables`             | Don’t import Variables from this file (required if not on the Enterprise Plan).                     |

--- a/www/src/pages/docs/reference/cli.md
+++ b/www/src/pages/docs/reference/cli.md
@@ -32,7 +32,7 @@ Generate code from `tokens.json` based on [plugins](/docs/integrations). Require
 npx tz build
 ```
 
-### Build Flags
+### Build flags
 
 | Name              | Description                                      |
 | :---------------- | :----------------------------------------------- |
@@ -46,6 +46,23 @@ Validate all DTCG tokens for syntax errors, and run any [linters](/docs/linting/
 ```sh
 npx tz check [filename]
 ```
+
+## Import
+
+Terrazzo allows importing from Figma files with the `import` command. Automatically import Figma Styles and Variables (note that Variables require an Enterprise plan; Styles work for any plan).
+
+```sh
+npx tz import https://www.figma.com/design/xxxxxxxxxxxxxxxxxvxxx/Design-System-Variables --output my-tokens.tokens.json
+```
+
+[See full guide](/docs/2.0/guides/import-from-figma)
+
+### Import flags
+
+| Name                           | Description                                                                                                                                                     |
+| :----------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--output [file]`, `-o [file]` | `.tokens.json` file to write to.                                                                                                                                |
+| `--unpublished`                | By default, this will grab the **published library** in the file. If you’d like to just simply grab what the file has, unpublished or not, add `--unpublished`. |
 
 ## Normalize
 
@@ -61,7 +78,7 @@ This will keep your tokens 100% as-authored, but will upgrade older DTCG files t
 | :-------------- | :--------------------- |
 | `--out` \| `-o` | Tokens file to output. |
 
-## Global Flags
+## Global flags
 
 Flags available for any command
 


### PR DESCRIPTION
## Changes

Adds back the often-requested import API, updated with Figma’s newest API. This only adds **styles**, but not variables (variables will happen in a followup).

Tests were added for Variables but they’re “lying” and will be updated when variable parsing lands.

## How to Review

- Tests added
