### PR TITLE
docs: Update Style Dictionary blurb

### DIFF
--- a/www/src/pages/docs/2.0/index.md
+++ b/www/src/pages/docs/2.0/index.md
@@ -37,27 +37,15 @@ This will create a `terrazzo.config.ts` starter config file, and even start your
 
 ## Comparison
 
-Whether you view your design tokens as **standard or nonstandard** will affect whether you use Terrazzo, some other tool like [Style Dictionary](https://amzn.github.io/style-dictionary/), or build your own. Terrazzo takes the same opinion as the DTCG format: **design tokens should be standardized.** This means that colors, typography, spacing, and more should be expressed in predictable ways.
-
-The advantage of using a standard format is you can get up-and-running faster because the tooling already exists. There’s more shared collaboration and tooling around the same problem, and knowledge sharing is easier. But the downside is it may not work well for nonstandard design systems, especially if your team approaches color, theming, or design systems in general in a unique way.
-
-### VS. Style Dictionary
-
-Style Dictionary is the path of nonstandard (custom) tokens. It allows your team to approach design systems in your own unique way… but at the cost of building your own tooling from scratch, and having to frontload investment before you get any value.
-
-:::warning
-
-While it’s tempting to lean toward _“flexibility,”_ that term is often indecision (or procrastination) in disguise! Make sure you’re prioritizing your **real needs today** rather than your potential needs tomorrow.
-
-:::
+- **vs [Style Dictionary](https://styledictionary.com/)**: Terrazzo is the only tool that supports the full DTCG format (support for resolvers and other 2025.10 features coming in 2.0!). But this will change as Style Dictionary is [now following Terrazzo’s path in adopting DTCG](https://github.com/style-dictionary/style-dictionary/issues/1590).
 
 ## API
 
 | Command                         | Description                                                                                                                   |
 | :------------------------------ | :---------------------------------------------------------------------------------------------------------------------------- |
 | `init`                          | Scaffold out a new project from an existing design system.                                                                    |
-| `build`                         | Build tokens [with your plugins](/docs/integrations) and also run [linting](/docs/linting).                              |
-| `lint`                          | Only run [token linting](/docs/linting) (not build).                                                                         |
+| `build`                         | Build tokens [with your plugins](/docs/integrations) and also run [linting](/docs/linting).                                   |
+| `lint`                          | Only run [token linting](/docs/linting) (not build).                                                                          |
 | `check [file]`                  | Validate a given tokens JSON meets the DTCG specification.                                                                    |
 | `bundle [file] --output [file]` | Bundle a [resolver](https://www.designtokens.org/tr/2025.10/resolver) that references multiple files into a single JSON file. |
 | `--help`                        | Display help message.                                                                                                         |

--- a/www/src/pages/docs/index.md
+++ b/www/src/pages/docs/index.md
@@ -37,30 +37,18 @@ This will create a `terrazzo.config.js` starter config file, and even start your
 
 ## Comparison
 
-Whether you view your design tokens as **standard or nonstandard** will affect whether you use Terrazzo, some other tool like [Style Dictionary](https://amzn.github.io/style-dictionary/), or build your own. Terrazzo takes the same opinion as the DTCG format: **design tokens should be standardized.** This means that colors, typography, spacing, and more should be expressed in predictable ways.
-
-The advantage of using a standard format is you can get up-and-running faster because the tooling already exists. There’s more shared collaboration and tooling around the same problem, and knowledge sharing is easier. But the downside is it may not work well for nonstandard design systems, especially if your team approaches color, theming, or design systems in general in a unique way.
-
-### VS. Style Dictionary
-
-Style Dictionary is the path of nonstandard (custom) tokens. It allows your team to approach design systems in your own unique way… but at the cost of building your own tooling from scratch, and having to frontload investment before you get any value.
-
-:::warning
-
-While it’s tempting to lean toward _“flexibility,”_ that term is often indecision (or procrastination) in disguise! Make sure you’re prioritizing your **real needs today** rather than your potential needs tomorrow.
-
-:::
+- **vs [Style Dictionary](https://styledictionary.com/)**: Terrazzo is the only tool that supports the full DTCG format (support for resolvers and other 2025.10 features coming in 2.0!). But this will change as Style Dictionary is [now following Terrazzo’s path in adopting DTCG](https://github.com/style-dictionary/style-dictionary/issues/1590).
 
 ## API
 
-| Command                 | Description                                                                                      |
-| :---------------------- | :----------------------------------------------------------------------------------------------- |
-| `init`                  | Scaffold out a new project from an existing design system.                                       |
+| Command                 | Description                                                                                 |
+| :---------------------- | :------------------------------------------------------------------------------------------ |
+| `init`                  | Scaffold out a new project from an existing design system.                                  |
 | `build`                 | Build tokens [with your plugins](/docs/integrations) and also run [linting](/docs/linting). |
-| `lint`                  | Only run [token linting](/docs/linting) (not build).                                            |
-| `check [file]`          | Validate a given tokens JSON meets the DTCG specification.                                       |
-| `--help`                | Display help message.                                                                            |
-| `--silent` \| `--quiet` | Suppress warnings and logs.                                                                      |
+| `lint`                  | Only run [token linting](/docs/linting) (not build).                                        |
+| `check [file]`          | Validate a given tokens JSON meets the DTCG specification.                                  |
+| `--help`                | Display help message.                                                                       |
+| `--silent` \| `--quiet` | Suppress warnings and logs.                                                                 |
 
 ### Debugging
 


### PR DESCRIPTION
## Changes

The section on Style Dictionary is now out of date because they’re [working on implementing the DTCG format](https://github.com/style-dictionary/style-dictionary/issues/1590). Update the section to reflect Style Dictionary’s change in project direction.

## How to Review

N/A
