### PR TITLE
Docs fixes

### DIFF
--- a/packages/tokens/src/space.tokens.yml
+++ b/packages/tokens/src/space.tokens.yml
@@ -57,4 +57,11 @@ space:
       unit: rem
   control-m:
     $type: dimension
-    $value: "{space.600}"
+    $value:
+      value: 2
+      unit: rem
+  control-l:
+    $type: dimension
+    $value:
+      value: 3
+      unit: rem

--- a/www/src/components/grid-button.astro
+++ b/www/src/components/grid-button.astro
@@ -1,0 +1,88 @@
+---
+export interface Props extends HTMLButtonElement {
+  variant?: 'default' | 'secondary' | 'lime' | 'blue' | 'orange';
+}
+
+const { type = 'button', variant = 'secondary', ...props } = Astro.props;
+---
+
+<button
+  class="grid-btn"
+  type={type}
+  data-variant={variant}
+  {...props}
+>
+  <slot />
+</button>
+
+<style is:global>
+.grid-btn {
+  --tz-button-text: var(--tz-color-bg-1);
+  --tz-button-bg: var(--tz-color-text-1);
+  --tz-button-border: var(--tz-button-bg);
+  --tz-button-height: var(--grid-size, 3rem);
+  --tz-button-gap: var(--tz-space-200);
+  --tz-button-padding: 1em;
+
+  align-items: center;
+  background-color: var(--tz-button-bg);
+  border-color: var(--tz-button-border);
+  border-radius: 0;
+  border-style: solid;
+  border-width: 1px;
+  color: var(--tz-button-text);
+  cursor: pointer;
+  display: inline-flex;
+  font-family: var(--tz-font-sans);
+  font-size: var(--tz-font-body-strong-font-size);
+  font-weight: var(--tz-font-body-strong-font-weight);
+  gap: var(--tz-button-gap);
+  min-height: var(--tz-button-height);
+  justify-content: center;
+  letter-spacing: var(--tz-font-body-strong-letter-spacing);
+  line-height: 1;
+  min-width: var(--grid-size);
+  outline-color: transparent;
+  outline-offset: 2px;
+  outline-style: solid;
+  outline-width: 2px;
+  padding-bottom: 0;
+  padding-left: var(--tz-button-padding);
+  padding-right: var(--tz-button-padding);
+  padding-top: 0;
+  text-decoration: none;
+
+  &:focus-visible {
+    outline-color: var(--tz-color-base-lime-600);
+  }
+
+  &[data-variant="lime"] {
+    --tz-button-bg: var(--tz-color-base-lime-600);
+    --tz-button-text: var(--tz-color-base-lime-200);
+    --tz-button-border: var(--tz-color-base-lime-400);
+  }
+
+  &[data-variant="blue"] {
+    --tz-button-bg: var(--tz-color-base-blue-700);
+    --tz-button-text: var(--tz-color-base-blue-200);
+    --tz-button-border: var(--tz-color-base-blue-500);
+  }
+
+  &[data-variant="orange"] {
+    --tz-button-bg: var(--tz-color-base-orange-700);
+    --tz-button-text: var(--tz-color-base-orange-200);
+    --tz-button-border: var(--tz-color-base-orange-500);
+  }
+
+  &[data-variant="secondary"] {
+    --tz-button-bg: var(--tz-color-bg-1);
+    --tz-button-border: var(--tz-color-border-1);
+    --tz-button-text: var(--tz-color-text-1);
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
+}
+</style>

--- a/www/src/components/grid-link-button.astro
+++ b/www/src/components/grid-link-button.astro
@@ -1,0 +1,18 @@
+---
+import './grid-button.astro'; // ensure CSS is always loaded
+
+export interface Props extends HTMLLinkElement {
+  href: string;
+  variant?: 'default' | 'secondary' | 'lime' | 'blue' | 'orange';
+}
+
+const { variant = 'secondary', ...props } = Astro.props;
+---
+
+<a
+  class="grid-btn"
+  data-variant={variant}
+  {...props}
+>
+  <slot />
+</a>

--- a/www/src/components/main-nav.astro
+++ b/www/src/components/main-nav.astro
@@ -1,6 +1,6 @@
 ---
 import { DiscordLogo, GitHubLogo } from '@terrazzo/icons';
-import { ButtonLink } from '@terrazzo/tiles';
+import GridLinkButton from './grid-link-button.astro';
 import Terrazzo from './terrazzo.astro';
 ---
 
@@ -11,7 +11,7 @@ import Terrazzo from './terrazzo.astro';
     </li>
     <li class="nav-item"><a href="/docs">Docs</a></li>
     <li class="nav-item nav-item--sub" style="margin-bottom:-1px">
-      <ButtonLink href="/docs" variant="lime">Get Started</ButtonLink>
+      <GridLinkButton href="/docs" variant="lime">Get Started</GridLinkButton>
     </li>
     <li class="nav-item nav-item--sub nav-item--secondary">
       <a

--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import { ButtonLink } from '@terrazzo/tiles';
+import GridLinkButton from '../components/grid-link-button.astro';
 import IlloHome from '../components/illo/home.astro';
 import Tri from '../components/tri.astro';
 import DefaultLayout from '../layouts/default.astro';
@@ -237,12 +237,10 @@ import DefaultLayout from '../layouts/default.astro';
       create and manage your design system. It’s free to use, forever. Keep full control
       over your design system!
     </p>
-    <menu class="cta">
-      <ButtonLink href="https://github.com/terrazzoapp/terrazzo" target="_blank"
-        >View on GitHub</ButtonLink
-      >
-      <ButtonLink href="/docs" variant="lime">Get Started</ButtonLink>
-    </menu>
+    <div class="cta">
+      <GridLinkButton href="https://github.com/terrazzoapp/terrazzo" target="_blank" style="min-width:calc(3 * var(--grid-size))">View on GitHub</GridLinkButton>
+      <GridLinkButton href="/docs" variant="lime" style="min-width:calc(3 * var(--grid-size))">Get Started</GridLinkButton>
+    </div>
   </section>
 </DefaultLayout>
 


### PR DESCRIPTION
## Changes

Fixes a homepage error where the buttons are squooshed from touching `@terrazzo/tiles`.

Pulls out some React components from `@terrazzo/tiles` into the docs, because the docs need different styling (marketing/docs styling is almost always different from product/UI styling). Going to start updating `@terrazzo/tiles` and having it not affect docs is important

## How to Review

N/A
