### PR TITLE
@terrazzo/react-color-picker@0.2.1

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terrazzo/icons",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "author": {
     "name": "Drew Powers",

--- a/packages/react-color-picker/CHANGELOG.md
+++ b/packages/react-color-picker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @terrazzo/react-color-picker
 
+## 0.2.1
+
+### Patch Changes
+
+- Fix color bug for out-of-gamut colors, minor performance improvements
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/react-color-picker/package.json
+++ b/packages/react-color-picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terrazzo/react-color-picker",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "React color picker that supports Color Module 4, wide color gamut (WCG), and Display-P3 using WebGL for monitor-accurate colors. Powered by colorjs.io.",
   "license": "MIT",
   "type": "module",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terrazzo/tokens",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Internal design tokens for @terrazzo/tiles",
   "type": "module",
   "author": {

--- a/packages/use-color/CHANGELOG.md
+++ b/packages/use-color/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @terrazzo/use-color
 
+## 0.2.1
+
+### Patch Changes
+
+- Fix color bug for out-of-gamut colors, minor performance improvements
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/use-color/package.json
+++ b/packages/use-color/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terrazzo/use-color",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "React hook for memoizing and transforming any web-compatible color. Uses Color.js.",
   "license": "MIT",
   "type": "module",

--- a/www/package.json
+++ b/www/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build:app": "astro build && cp -r ../packages/storybook/storybook dist",
+    "build:app": "astro build && cp -r ../packages/storybook/storybook dist && cp -r ../packages/token-lab/dist dist/lab",
     "dev": "astro dev",
     "format": "biome check --fix --unsafe src",
     "lint": "pnpm --filter @terrazzo/www run \"/^lint:(js|css)/\"",
@@ -31,6 +31,7 @@
     "@astrojs/react": "4.4.2",
     "@astrojs/sitemap": "^3.7.0",
     "@terrazzo/storybook": "workspace:^",
+    "@terrazzo/token-lab": "workspace:^",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "astro": "^5.17.3",

--- a/www/src/pages/token-lab/index.astro
+++ b/www/src/pages/token-lab/index.astro
@@ -1,7 +1,0 @@
----
-import DefaultLayout from '../../layouts/default.astro';
----
-
-<DefaultLayout>
-  <h1>Token Lab</h1>
-</DefaultLayout>


### PR DESCRIPTION
## Changes

Version `@terrazzo/react-color-picker` and `@terrazzo/use-color`.

Also publish WIP token lab to `/lab` which is bad for a versioning PR, but these packages will be part of that work

## How to Review

N/A
