### PR TITLE
Feature request: Partial resolver application

### DIFF
--- a/packages/parser/src/lib/resolver-utils.ts
+++ b/packages/parser/src/lib/resolver-utils.ts
@@ -1,3 +1,4 @@
+import type { ResolverApplicationOptions } from '../types.js';
 import { alphaComparator } from './array.js';
 
 /**
@@ -28,13 +29,20 @@ export function filterResolverPaths(path: string[]): string[] {
 }
 
 /** Make a deterministic string from an object */
-export function getPermutationID(input: Record<string, string | undefined>): string {
-  const keys = Object.keys(input).sort(alphaComparator);
-  const sortedInput = {} as typeof input;
-  for (const k of keys) {
-    sortedInput[k] = input[k];
-  }
-  return JSON.stringify(sortedInput);
+export function getPermutationID(
+  input: Record<string, string | undefined>,
+  options?: ResolverApplicationOptions | undefined,
+): string {
+  const stableInput = Object.fromEntries(Object.entries(input).sort(([a], [b]) => alphaComparator(a, b)));
+  return JSON.stringify(
+    options
+      ? {
+          input: stableInput,
+          sets: options?.sets?.sort(alphaComparator),
+          modifiers: options?.modifiers?.sort(alphaComparator),
+        }
+      : stableInput,
+  );
 }
 
 /**

--- a/packages/parser/src/resolver/load.ts
+++ b/packages/parser/src/resolver/load.ts
@@ -124,7 +124,7 @@ export function createResolver(
     apply(inputRaw, options) {
       const tokensRaw: TokenNormalizedSet = {};
       const input = { ...inputDefaults, ...inputRaw };
-      const permutationID = getPermutationID(input);
+      const permutationID = getPermutationID(input, options);
 
       if (resolverCache[permutationID]) {
         return resolverCache[permutationID];
@@ -133,14 +133,18 @@ export function createResolver(
       for (const item of resolverSource.resolutionOrder) {
         switch (item.type) {
           case 'set': {
-            if (options?.sets && !options.sets.includes(item.name)) continue;
+            if (options?.sets && !options.sets.includes(item.name)) {
+              continue;
+            }
             for (const s of item.sources) {
               destructiveMerge(tokensRaw, s);
             }
             break;
           }
           case 'modifier': {
-            if (options?.modifiers && !options.modifiers.includes(item.name)) continue;
+            if (options?.modifiers && !options.modifiers.includes(item.name)) {
+              continue;
+            }
             const context = input[item.name]!;
             const sources = item.contexts[context];
             if (!sources) {

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -339,6 +339,11 @@ export interface ReferenceObject {
 
 export type ResolverInput = Record<string, string>;
 
+export type ResolverApplicationOptions = {
+  sets?: string[];
+  modifiers?: string[];
+};
+
 export interface Resolver<
   Inputs extends Record<string, string[]> = Record<string, string[]>,
   Input = Record<keyof Inputs, Inputs[keyof Inputs][number]>,
@@ -349,7 +354,7 @@ export interface Resolver<
    * results (it ignores object key order, and takes defaults into account for
    * better caching).
    */
-  apply: (input: Partial<Input>, options?: {sets?: string[], modifiers?: string[]}) => TokenNormalizedSet;
+  apply: (input: Partial<Input>, options?: ResolverApplicationOptions) => TokenNormalizedSet;
   /**
    * List all possible valid input combinations. Ignores default values, as they
    * would duplicate some other permutations. This also caches results, so it’s

--- a/packages/parser/test/lib/resolver-utils.test.ts
+++ b/packages/parser/test/lib/resolver-utils.test.ts
@@ -79,4 +79,8 @@ it('getPermutationID', () => {
   expect(getPermutationID({ a: 'A', c: 'C', b: 'B' })).toBe('{"a":"A","b":"B","c":"C"}');
   expect(getPermutationID({ 0: '0', 11: '11', 2: '2' })).toBe('{"0":"0","2":"2","11":"11"}');
   expect(getPermutationID({})).toBe('{}');
+
+  expect(getPermutationID({ a: 'A', b: 'B' }, { sets: ['d', 'c'], modifiers: ['y', 'x'] })).toBe(
+    '{"input":{"a":"A","b":"B"},"sets":["c","d"],"modifiers":["x","y"]}',
+  );
 });


### PR DESCRIPTION
## Changes

Adds an option to `apply` which allows users to focus only on tokens they know they need. 

The use case for this is when outputting only a subset of tokens the resolver will (re)apply _all_ sets and modifiers.

For instance, if you are outputting tokens for light/dark modes, there is no need to apply inputs to your typography tokens.

```json
{
  "sets": {
    "primitives": [...],
    "typography": [...],
  },
  "modifiers": {
    "mode": {
      "contexts": {
        "light": [{...}],
        "dark": [{...}],
      }
    }
  }
}
```

```ts
const tokens = resolve.apply({ mode: 'light' }, { sets: ['primitives'], modifiers: ['mode'] });
```

This is definitely advanced usage, and requires manual fettling of the options to ensure everything comes through correctly, but can offer reasonable performance improvements - I'm seeing my builds locally drop from ~12.5s to ~8s.