### PR TITLE
chore: bump test timeout

### DIFF
--- a/packages/plugin-css/test/cli.test.ts
+++ b/packages/plugin-css/test/cli.test.ts
@@ -47,15 +47,19 @@ describe('fixtures', () => {
     ['multiple outputs', { dir: 'mulitiple-outputs', output: ['tokens-default.css', 'tokens-brand2.css'] }],
   ];
 
-  it.each(tests)('%s', async (_, { dir, config, output }) => {
-    const cwd = new URL(dir.replace(/\/?$/, '/'), FIXTURE_ROOT);
-    await execaNode({ cwd })`${cmd} build${config ? ` -c ${config}` : ''}`;
-    for (const file of output) {
-      await expect(await fs.readFile(new URL(file, cwd), 'utf8')).toMatchFileSnapshot(
-        fileURLToPath(new URL(file.replace(/\.css$/, '.want.css'), cwd)),
-      );
-    }
-  });
+  it.each(tests)(
+    '%s',
+    async (_, { dir, config, output }) => {
+      const cwd = new URL(dir.replace(/\/?$/, '/'), FIXTURE_ROOT);
+      await execaNode({ cwd })`${cmd} build${config ? ` -c ${config}` : ''}`;
+      for (const file of output) {
+        await expect(await fs.readFile(new URL(file, cwd), 'utf8')).toMatchFileSnapshot(
+          fileURLToPath(new URL(file.replace(/\.css$/, '.want.css'), cwd)),
+        );
+      }
+    },
+    60_000, // The DS tests need more time on Windows in CI
+  );
 });
 
 describe('CLI', () => {


### PR DESCRIPTION
## Changes

Fixes failing Windows tests which don’t complete in 5s in CI. Bumps to 60s. Accidentally regressed with #690.

## How to Review

- CI should pass
