### PR TITLE
docs: Fix broken-link

### DIFF
--- a/www/src/pages/docs/index.md
+++ b/www/src/pages/docs/index.md
@@ -9,7 +9,7 @@ Terrazzo takes DTCG design token JSON and generates code for any platform (e.g. 
 
 :::tip
 
-Migrating from Cobalt? Check out the [Migration Guide](/docs/guides/migrating-cobalt)
+Migrating from 0.x? Check out the [Migration Guide](/docs/guides/migrating-v2).
 
 :::
 


### PR DESCRIPTION
## Changes

It’s always _right_ after you publish, too.

## How to Review

- Docs-only change
