### PR TITLE
feat(react-color-picker): add color space restriction via component prop

### DIFF
--- a/.changeset/restrict-color-picker-spaces.md
+++ b/.changeset/restrict-color-picker-spaces.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/react-color-picker": minor
+---
+
+[react-color-picker]: restrict color space dropdown via `colorSpaces` prop to ColorPicker component

--- a/packages/react-color-picker/README.md
+++ b/packages/react-color-picker/README.md
@@ -16,7 +16,11 @@ import { useState } from "react";
 
 const [color, setColor] = useState("color(display-p3 0 0.3 1)");
 
-<ColorPicker value={color} onChange={setColor} />;
+<ColorPicker
+  color={color}
+  setColor={setColor}
+  colorSpaces={["srgb", "oklch", "oklab"]}
+/>;
 ```
 
 ### Styling

--- a/packages/react-color-picker/src/components/ColorPicker.tsx
+++ b/packages/react-color-picker/src/components/ColorPicker.tsx
@@ -21,18 +21,34 @@ export const COLOR_PICKER_SPACES = {
   'xyz-d65': 'XYZ (D65)',
 };
 
+export type ColorPickerSpace = keyof typeof COLOR_PICKER_SPACES;
+
 export interface ColorPickerProps extends Omit<ComponentProps<'div'>, 'color'> {
   /** value from useColor() */
   color: ReturnType<typeof useColor>[0];
+  colorSpaces?: ColorPickerSpace[];
   setColor: ReturnType<typeof useColor>[1];
 }
 
-export default function ColorPicker({ className, color, setColor, ...rest }: ColorPickerProps) {
+export default function ColorPicker({ className, color, colorSpaces, setColor, ...rest }: ColorPickerProps) {
   const [codeColor, setCodeColor] = useState(color.css);
   const [maxGamut] = useState<Gamut>('srgb');
   const normalizedColorMode = useMemo(
     () => (['p3', 'rec2020', 'srgb-linear'].includes(color.original.space.id) ? 'srgb' : color.original.space.id),
     [color],
+  );
+  const selectableColorSpaces = useMemo(() => {
+    if (!colorSpaces) {
+      return Object.entries(COLOR_PICKER_SPACES);
+    }
+    return Object.entries(COLOR_PICKER_SPACES).filter(([id]) => colorSpaces.includes(id as ColorPickerSpace));
+  }, [colorSpaces]);
+  const selectedColorMode = useMemo(
+    () =>
+      selectableColorSpaces.some(([id]) => id === normalizedColorMode)
+        ? normalizedColorMode
+        : selectableColorSpaces[0]?.[0],
+    [normalizedColorMode, selectableColorSpaces],
   );
   useEffect(() => {
     setCodeColor(color.css);
@@ -51,13 +67,13 @@ export default function ColorPicker({ className, color, setColor, ...rest }: Col
       </div>
       <div className='tz-color-picker-colorspace'>
         <Select
-          value={normalizedColorMode}
+          value={selectedColorMode}
           trigger={color.original.space.id}
           onValueChange={(colorSpace) => {
             setColor(convert(color.original, colorSpace, { inGamut: { space: maxGamut } }) as any);
           }}
         >
-          {Object.entries(COLOR_PICKER_SPACES).map(([id, label]) => (
+          {selectableColorSpaces.map(([id, label]) => (
             <SelectItem key={id} value={id} icon={<ColorFilterOutline />}>
               {label}
             </SelectItem>

--- a/packages/storybook/src/ColorPicker.stories.jsx
+++ b/packages/storybook/src/ColorPicker.stories.jsx
@@ -16,3 +16,13 @@ export const Overview = {
     return <ColorPicker {...args} color={color} setColor={setColor} />;
   },
 };
+
+export const RestrictedColorSpaces = {
+  args: {
+    colorSpaces: ['srgb', 'oklch', 'oklab'],
+  },
+  render(args) {
+    const [color, setColor] = useColor('oklch(0.7 0.18 280)');
+    return <ColorPicker {...args} color={color} setColor={setColor} />;
+  },
+};


### PR DESCRIPTION
## Changes

This PR adds a optional `colorSpaces` prop to `ColorPicker` component that allows configuration of available color spaces in dropdown 

Related issue - https://github.com/terrazzoapp/terrazzo/issues/693


## How to Review

There are no existing tests for this package but I've added a new story for Storybook if that counts
