### PR TITLE
fix(plugin-tailwind): write template path relative to cwd in file header

### DIFF
--- a/.changeset/tailwind-relative-template-path.md
+++ b/.changeset/tailwind-relative-template-path.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/plugin-tailwind": patch
+---
+
+plugin-tailwind: write the template path in the generated file header relative to cwd so builds stay deterministic across machines (previously an absolute path like `/Users/alice/...` could leak into committed output)

--- a/packages/plugin-tailwind/src/index.ts
+++ b/packages/plugin-tailwind/src/index.ts
@@ -1,5 +1,7 @@
 import fsSync from 'node:fs';
 import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { Plugin } from '@terrazzo/parser';
 import { FORMAT_ID as FORMAT_CSS } from '@terrazzo/plugin-css';
 import { makeCSSVar } from '@terrazzo/token-tools/css';
@@ -101,7 +103,11 @@ export default function pluginTailwind(options: TailwindPluginOptions): Plugin {
         generatedTemplate = `${generatedTemplate.slice(0, start)}${tokens.map((t) => `${t.localID}: ${t.value};`).join(`\n${indent}`)}${generatedTemplate.slice(end)}`;
       }
       // Note: don’t append the header till the end, otherwise start/end will all be wrong
-      outputFile(filename, `${buildFileHeader(options.template)}\n\n${generatedTemplate}`);
+      const templateRel = path
+        .relative(fileURLToPath(cwd), fileURLToPath(new URL(options.template, cwd)))
+        .split(path.sep)
+        .join('/');
+      outputFile(filename, `${buildFileHeader(templateRel)}\n\n${generatedTemplate}`);
     },
   };
 }


### PR DESCRIPTION
## Summary

First of all, thank you for building and maintaining Terrazzo — the Tailwind plugin has been a joy to adopt. This is a small follow-up to #646 that I'd like to propose for your consideration.

Currently, `@terrazzo/plugin-tailwind` writes `options.template` verbatim into the generated file header:

```css
/* -------------------------------------------
 *  Autogenerated by ⛋ Terrazzo. DO NOT EDIT!
 *  template: /Users/alice/work/app/tokens/tailwind.template.css
 * ------------------------------------------- */
```

If a user passes an absolute path (or a tool resolves one for them), that absolute path lands in the committed output file. This causes two small but real problems:

1. **Non-deterministic builds across machines** — the same config produces different output on a teammate's laptop or in CI, creating noisy diffs.
2. **Leaks local paths** — `/Users/<name>/...` or `/home/<name>/...` ends up in version control.

## Fix

Resolve the template path relative to `cwd` (the parent of `outDir`, matching how the plugin already locates the template file at runtime) before handing it to `buildFileHeader`. Separators are normalized to `/` so Windows and POSIX produce identical output.

The behavior for users who already pass a relative path (like the existing test fixtures) is unchanged — `path.relative` is a no-op in that case, so no snapshots needed updating.

## Test plan

- [x] `pnpm test` in `packages/plugin-tailwind` (18 passed)
- [x] Existing `legacy-modes` and `resolver` fixtures still match their snapshots
- [x] Changeset added (`patch` for `@terrazzo/plugin-tailwind`)