### PR TITLE
fix: avoid duplicate WideGamutColorValue when downsampled gamuts are identical

### DIFF
--- a/.changeset/calm-beds-drum.md
+++ b/.changeset/calm-beds-drum.md
@@ -1,0 +1,5 @@
+---
+"@terrazzo/token-tools": patch
+---
+
+fix: avoid duplicate WideGamutColorValue when downsampled gamuts are identical

--- a/packages/token-tools/src/css/color.ts
+++ b/packages/token-tools/src/css/color.ts
@@ -51,7 +51,11 @@ export type Depth = keyof typeof DEPTH_ROUNDING | 'unlimited';
 /**
  * Downsample color to srgb, display-p3, and rec2020 color spaces.
  */
-function downsample($value: ColorTokenNormalized['$value'], color: ColorConstructor, depth: Depth = 30) {
+function downsample(
+  $value: ColorTokenNormalized['$value'],
+  color: ColorConstructor,
+  depth: Depth = 30,
+): TokenTransformed['value'] {
   const srgb = convert(color, $value.colorSpace, { inGamut: { space: 'srgb' } });
   const p3 = convert(color, $value.colorSpace, { inGamut: { space: 'p3' } });
   const rec2020 = convert(color, $value.colorSpace, { inGamut: { space: 'rec2020' } });
@@ -59,10 +63,14 @@ function downsample($value: ColorTokenNormalized['$value'], color: ColorConstruc
     throw new Error(`Invalid bit depth: ${depth}. Supported values: ${Object.keys(DEPTH_ROUNDING).join(', ')}`);
   }
   const precision = DEPTH_ROUNDING[depth as keyof typeof DEPTH_ROUNDING] || undefined;
-  return {
+  const result: WideGamutColorValue = {
     '.': serialize(color, { precision }),
     srgb: serialize(srgb, { precision }),
     p3: serialize(p3, { precision }),
     rec2020: serialize(rec2020, { precision }),
   };
+  if (result['.'] === result.srgb && result['.'] === result.p3 && result['.'] === result.rec2020) {
+    return result['.'];
+  }
+  return result;
 }

--- a/packages/token-tools/test/css.test.ts
+++ b/packages/token-tools/test/css.test.ts
@@ -402,6 +402,18 @@ describe('transformColor', () => {
       },
     ],
     [
+      'oklch (out of gamut, but rounds to same)',
+      {
+        given: [
+          { $value: { colorSpace: 'oklch', components: [0.6011, 0.1427, 157.18], alpha: 1 } },
+          { tokensSet: {}, color: { depth: 30 }, permutation: {} },
+        ],
+        want: {
+          success: 'oklch(60.11% 0.1427 157.2)',
+        },
+      },
+    ],
+    [
       'okhsv',
       {
         given: [


### PR DESCRIPTION
## Summary

Fixes #712

When `transformColor` downsamples an out-of-gamut color, rounding at lower bit depths (e.g. default `depth=30`, precision=4) can cause all gamut-mapped variants (`srgb`, `p3`, `rec2020`) to serialize to the same string as the original. Previously this returned a `WideGamutColorValue` object with four identical strings, which is wasteful and misleading.

## Changes

**`packages/token-tools/src/css/color.ts`**
- Modified `downsample()` to compare all four serialized outputs after rounding
- When all gamut variants are identical, returns a plain `string` instead of the `WideGamutColorValue` object
- The return type `TokenTransformed['value']` already supported both `string` and `WideGamutColorValue`

**`packages/token-tools/test/css.test.ts`**
- Added test case using the exact reproduction from the issue (`oklch(0.6011, 0.1427, 157.18)` with `depth: 30`)
- Verifies that the result is a single string, not a four-field object with identical values

## Reproduction

Before this fix:
```js
transformColor(
  { $type: 'color', $value: { colorSpace: 'oklch', components: [0.6011, 0.1427, 157.18] } },
  { tokensSet: {}, color: { depth: 30 } }
)
// Returns: { '.': 'oklch(60.11% 0.1427 157.2)', srgb: 'oklch(60.11% 0.1427 157.2)', p3: 'oklch(60.11% 0.1427 157.2)', rec2020: 'oklch(60.11% 0.1427 157.2)' }
```

After this fix:
```js
// Returns: 'oklch(60.11% 0.1427 157.2)'
```

## Test plan

- [x] All 73 existing tests in `packages/token-tools/` pass
- [x] New test case added for the exact issue reproduction
- [x] Verified no regressions in existing out-of-gamut color tests