### PR TITLE
Fix token aliases

### DIFF
--- a/.changeset/gentle-pumas-count.md
+++ b/.changeset/gentle-pumas-count.md
@@ -1,0 +1,14 @@
+---
+"@terrazzo/plugin-css": patch
+"@terrazzo/parser": patch
+"@terrazzo/cli": patch
+"@terrazzo/plugin-css-in-js": patch
+"@terrazzo/plugin-js": patch
+"@terrazzo/plugin-sass": patch
+"@terrazzo/plugin-tailwind": patch
+"@terrazzo/plugin-token-listing": patch
+"@terrazzo/plugin-vanilla-extract": patch
+"@terrazzo/token-tools": patch
+---
+
+Improve token aliases where the primitive or primary has token, but aliases do not. This leads to dropped tokens in all plugins.

--- a/packages/parser/src/parse/token.ts
+++ b/packages/parser/src/parse/token.ts
@@ -274,7 +274,11 @@ export function graphAliases(refMap: RefMap, { tokens, logger, sources }: GraphA
 
     // Top alias
     const isTopLevelAlias = jsonID.endsWith('/$value') || tokens[jsonID];
-    if (isTopLevelAlias) {
+    const isSameModeAlias =
+      mode !== '.' &&
+      jsonID.endsWith(`/$extensions/mode/${mode}`) &&
+      refChain.at(-1)?.endsWith(`/$extensions/mode/${mode}`);
+    if (isTopLevelAlias || isSameModeAlias) {
       modeValue.aliasOf = refToTokenID(refChain.at(-1)!);
       const aliasChain = refChain.map(refToTokenID) as string[];
       modeValue.aliasChain = [...aliasChain];
@@ -283,6 +287,7 @@ export function graphAliases(refMap: RefMap, { tokens, logger, sources }: GraphA
     // Partial alias
     const partial = jsonID
       .replace(/.*\/\$value\/?/, '')
+      .replace(/.*\/\$extensions\/mode\/[^/]+/, '')
       .split('/')
       .filter(Boolean);
     if (partial.length && modeValue.$value && typeof modeValue.$value === 'object') {
@@ -537,13 +542,55 @@ export function resolveAliases(
 
         refMap[path.join('/')] = { filename: token.source.filename!, refChain };
 
+        // handle legacy $extensions.modes on upstream alias, that may/may not exist on downstream token
+        const anyUpstreamHasModes = refChain.some((ref) => {
+          const jsonID = ref.replace(/\/(\$value|\$extensions\/mode\/).*/, '');
+          return Object.keys(tokens[jsonID]?.mode ?? {}).length > 1;
+        });
+        const currentHasModes = Object.keys(token.mode).length > 1;
+        if (mode === '.' && !currentHasModes && anyUpstreamHasModes) {
+          for (const altMode of Object.keys(tokens[resolvedID]!.mode)) {
+            if (altMode === '.') {
+              continue;
+            }
+            const altModePath = _injectMode(path.join('/'), altMode);
+            const partialProperty = altModePath.match(/\$extensions\/mode\/[^/]+\/(.*)/)?.[1];
+            // append, never overwrite
+            if (!refMap[altModePath]) {
+              refMap[altModePath] = {
+                filename: token.source.filename!,
+                refChain: refChain.map((id) => _injectMode(id, altMode)),
+              };
+              if (!token.mode[altMode]) {
+                token.mode[altMode] = {
+                  ...token.mode['.'],
+                  aliasOf: undefined,
+                  partialAliasOf: undefined,
+                  aliasedBy: undefined,
+                };
+              }
+              if (partialProperty) {
+                if (
+                  typeof token.mode[altMode].$value === 'object' &&
+                  (tokens[resolvedID]?.mode[altMode]?.$value as any)[partialProperty]
+                ) {
+                  (token.mode[altMode].$value as any)[partialProperty] = (
+                    tokens[resolvedID]?.mode[altMode]?.$value as any
+                  )[partialProperty];
+                }
+              } else {
+                token.mode[altMode].$value = tokens[resolvedID]!.mode[altMode]!.$value;
+              }
+            }
+          }
+        }
+
         return {
           $type: tokens[resolvedID]!.$type,
           $value: tokens[resolvedID]!.mode[mode]?.$value || tokens[resolvedID]!.$value,
         };
       }
 
-      // resolve DTCG aliases without
       const pathBase = mode === '.' ? token.jsonID : `${token.jsonID}/$extensions/mode/${mode}`;
       const { $type, $value } = traverseAndResolve(token.mode[mode]!.$value, {
         node: aliasEntry.node!,
@@ -558,4 +605,9 @@ export function resolveAliases(
       }
     }
   }
+}
+
+/** ⚠️ Don’t use outside this context. This is for edge cases with legacy modes where we need to hoist modes to downstream aliases. */
+function _injectMode(ref: string, mode: string) {
+  return ref.replace(/\/\$value$/, `/$extensions/mode/${mode}`).replace(/\/\$value\//, `/$extensions/mode/${mode}/`);
 }

--- a/packages/plugin-css/src/build.ts
+++ b/packages/plugin-css/src/build.ts
@@ -264,7 +264,7 @@ export default function buildCSS({
         ? token.token.mode[selector.mode]!.aliasedBy
         : token.token.aliasedBy;
       let aliasTokens = aliasedBy?.length
-        ? getTransforms({ format: FORMAT_ID, id: aliasedBy, mode: [selector.mode, '.'] })
+        ? getTransforms({ format: FORMAT_ID, id: aliasedBy, mode: selector.mode })
         : [];
       // Note: this will grab aliases from alternate and default modes. If we have duplicates, discard the default modes
       const uniqueAliasIDs = new Set(aliasTokens.map((t) => t.id));

--- a/packages/plugin-css/test/fixtures/mode-type-border/index.want.css
+++ b/packages/plugin-css/test/fixtures/mode-type-border/index.want.css
@@ -44,18 +44,26 @@
 
 @media (prefers-color-scheme: light) {
   :root {
-    --ds-color-border: var(--ds-color-base-gray-20);
-    --ds-border-thick: 2.5px solid var(--ds-color-border);
-    --ds-color-red: oklch(63.47% 0.254 16.44);
+    --ds-border-color: rgb(65.098% 69.02% 70.98%);
+    --ds-border-dashed: 1.5px dashed var(--ds-border-color);
+    --ds-border-ridge: 1px ridge var(--ds-border-color);
+    --ds-border-solid: 1px solid var(--ds-border-color);
+    --ds-border-default: var(--ds-border-solid);
     --ds-border-red: 1px solid var(--ds-color-red);
+    --ds-color-border: var(--ds-color-base-gray-20);
+    --ds-color-red: oklch(63.47% 0.254 16.44);
   }
 }
 
 [data-color-theme="light"] {
-  --ds-color-border: var(--ds-color-base-gray-20);
-  --ds-border-thick: 2.5px solid var(--ds-color-border);
-  --ds-color-red: oklch(63.47% 0.254 16.44);
+  --ds-border-color: rgb(65.098% 69.02% 70.98%);
+  --ds-border-dashed: 1.5px dashed var(--ds-border-color);
+  --ds-border-ridge: 1px ridge var(--ds-border-color);
+  --ds-border-solid: 1px solid var(--ds-border-color);
+  --ds-border-default: var(--ds-border-solid);
   --ds-border-red: 1px solid var(--ds-color-red);
+  --ds-color-border: var(--ds-color-base-gray-20);
+  --ds-color-red: oklch(63.47% 0.254 16.44);
 }
 
 @media (color-gamut: p3) {
@@ -88,18 +96,26 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --ds-color-border: var(--ds-color-base-gray-80);
-    --ds-border-thick: 2.5px solid var(--ds-color-border);
-    --ds-color-red: oklch(35.3% 0.1414 18.14);
+    --ds-border-color: rgb(7.8431% 9.0196% 10.588%);
+    --ds-border-dashed: 1.5px dashed var(--ds-border-color);
+    --ds-border-ridge: 1px ridge var(--ds-border-color);
+    --ds-border-solid: 1px solid var(--ds-border-color);
+    --ds-border-default: var(--ds-border-solid);
     --ds-border-red: 1px solid var(--ds-color-red);
+    --ds-color-border: var(--ds-color-base-gray-80);
+    --ds-color-red: oklch(35.3% 0.1414 18.14);
   }
 }
 
 [data-color-theme="dark"] {
-  --ds-color-border: var(--ds-color-base-gray-80);
-  --ds-border-thick: 2.5px solid var(--ds-color-border);
-  --ds-color-red: oklch(35.3% 0.1414 18.14);
+  --ds-border-color: rgb(7.8431% 9.0196% 10.588%);
+  --ds-border-dashed: 1.5px dashed var(--ds-border-color);
+  --ds-border-ridge: 1px ridge var(--ds-border-color);
+  --ds-border-solid: 1px solid var(--ds-border-color);
+  --ds-border-default: var(--ds-border-solid);
   --ds-border-red: 1px solid var(--ds-color-red);
+  --ds-color-border: var(--ds-color-base-gray-80);
+  --ds-color-red: oklch(35.3% 0.1414 18.14);
 }
 
 @media (color-gamut: p3) {

--- a/packages/plugin-css/test/fixtures/mode-type-border/terrazzo.config.ts
+++ b/packages/plugin-css/test/fixtures/mode-type-border/terrazzo.config.ts
@@ -10,41 +10,13 @@ export default defineConfig({
       filename: 'index.css',
       variableName: (token) => makeCSSVar(token.id, { prefix: 'ds' }),
       modeSelectors: [
-        {
-          mode: 'light',
-          tokens: ['color.**', 'gradient.**'],
-          selectors: ['@media (prefers-color-scheme: light)', '[data-color-theme="light"]'],
-        },
-        {
-          mode: 'dark',
-          tokens: ['color.**', 'gradient.**'],
-          selectors: ['@media (prefers-color-scheme: dark)', '[data-color-theme="dark"]'],
-        },
-        {
-          mode: 'light-colorblind',
-          tokens: ['color.**'],
-          selectors: ['[data-color-theme="light-colorblind"]'],
-        },
-        {
-          mode: 'light-high-contrast',
-          tokens: ['color.**'],
-          selectors: ['[data-color-theme="light-high-contrast"]'],
-        },
-        {
-          mode: 'dark-dimmed',
-          tokens: ['color.**'],
-          selectors: ['[data-color-theme="dark-dimmed"]'],
-        },
-        {
-          mode: 'dark-high-contrast',
-          tokens: ['color.**'],
-          selectors: ['[data-color-theme="dark-high-contrast"]'],
-        },
-        {
-          mode: 'dark-colorblind',
-          tokens: ['color.**'],
-          selectors: ['[data-color-theme="dark-colorblind"]'],
-        },
+        { mode: 'light', selectors: ['@media (prefers-color-scheme: light)', '[data-color-theme="light"]'] },
+        { mode: 'dark', selectors: ['@media (prefers-color-scheme: dark)', '[data-color-theme="dark"]'] },
+        { mode: 'light-colorblind', selectors: ['[data-color-theme="light-colorblind"]'] },
+        { mode: 'light-high-contrast', selectors: ['[data-color-theme="light-high-contrast"]'] },
+        { mode: 'dark-dimmed', selectors: ['[data-color-theme="dark-dimmed"]'] },
+        { mode: 'dark-high-contrast', selectors: ['[data-color-theme="dark-high-contrast"]'] },
+        { mode: 'dark-colorblind', selectors: ['[data-color-theme="dark-colorblind"]'] },
         { mode: 'desktop', selectors: ['@media (width >= 600px)'] },
       ],
     })

--- a/packages/plugin-css/test/fixtures/mode-type-color/index.want.css
+++ b/packages/plugin-css/test/fixtures/mode-type-color/index.want.css
@@ -42,6 +42,11 @@
 
 @media (prefers-color-scheme: light) {
   :root {
+    --ds-color-alias-1: var(--ds-color-blue-6);
+    --ds-color-alias-2: var(--ds-color-alias-1);
+    --ds-color-alias-3: var(--ds-color-alias-2);
+    --ds-color-alias-4: var(--ds-color-alias-3);
+    --ds-color-alias-5: var(--ds-color-alias-4);
     --ds-color-blue-0: rgb(86.667% 95.686% 100%);
     --ds-color-blue-1: rgb(71.373% 89.02% 100%);
     --ds-color-blue-2: rgb(50.196% 80% 100%);
@@ -60,6 +65,11 @@
 }
 
 [data-color-theme="light"] {
+  --ds-color-alias-1: var(--ds-color-blue-6);
+  --ds-color-alias-2: var(--ds-color-alias-1);
+  --ds-color-alias-3: var(--ds-color-alias-2);
+  --ds-color-alias-4: var(--ds-color-alias-3);
+  --ds-color-alias-5: var(--ds-color-alias-4);
   --ds-color-blue-0: rgb(86.667% 95.686% 100%);
   --ds-color-blue-1: rgb(71.373% 89.02% 100%);
   --ds-color-blue-2: rgb(50.196% 80% 100%);
@@ -106,6 +116,11 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
+    --ds-color-alias-1: var(--ds-color-blue-6);
+    --ds-color-alias-2: var(--ds-color-alias-1);
+    --ds-color-alias-3: var(--ds-color-alias-2);
+    --ds-color-alias-4: var(--ds-color-alias-3);
+    --ds-color-alias-5: var(--ds-color-alias-4);
     --ds-color-blue-0: rgb(79.216% 90.98% 100%);
     --ds-color-blue-1: rgb(64.706% 83.922% 100%);
     --ds-color-blue-2: rgb(47.451% 75.294% 100%);
@@ -124,6 +139,11 @@
 }
 
 [data-color-theme="dark"] {
+  --ds-color-alias-1: var(--ds-color-blue-6);
+  --ds-color-alias-2: var(--ds-color-alias-1);
+  --ds-color-alias-3: var(--ds-color-alias-2);
+  --ds-color-alias-4: var(--ds-color-alias-3);
+  --ds-color-alias-5: var(--ds-color-alias-4);
   --ds-color-blue-0: rgb(79.216% 90.98% 100%);
   --ds-color-blue-1: rgb(64.706% 83.922% 100%);
   --ds-color-blue-2: rgb(47.451% 75.294% 100%);
@@ -169,6 +189,11 @@
 }
 
 [data-color-theme="light-colorblind"] {
+  --ds-color-alias-1: var(--ds-color-blue-6);
+  --ds-color-alias-2: var(--ds-color-alias-1);
+  --ds-color-alias-3: var(--ds-color-alias-2);
+  --ds-color-alias-4: var(--ds-color-alias-3);
+  --ds-color-alias-5: var(--ds-color-alias-4);
   --ds-color-blue-0: rgb(86.667% 95.686% 100%);
   --ds-color-blue-1: rgb(71.373% 89.02% 100%);
   --ds-color-blue-2: rgb(50.196% 80% 100%);
@@ -176,14 +201,7 @@
   --ds-color-blue-4: rgb(12.941% 54.51% 100%);
   --ds-color-blue-5: rgb(3.5294% 41.176% 85.49%);
   --ds-color-blue-6: rgb(1.9608% 31.373% 68.235%);
-  --ds-color-alias-1: var(--ds-color-blue-6);
-  --ds-color-alias-2: var(--ds-color-alias-1);
-  --ds-color-alias-3: var(--ds-color-alias-2);
-  --ds-color-alias-4: var(--ds-color-alias-3);
-  --ds-color-alias-5: var(--ds-color-alias-4);
-  --ds-color-text-action: var(--ds-color-blue-6);
   --ds-color-blue-7: rgb(1.1765% 23.922% 54.51%);
-  --ds-color-control-border-focus: var(--ds-color-blue-7);
   --ds-color-blue-8: rgb(3.9216% 18.824% 41.176%);
   --ds-color-blue-9: rgb(0% 12.941% 33.333%);
   --ds-color-hdr-blue: oklch(63.34% 0.2011 253.9);
@@ -205,6 +223,11 @@
 }
 
 [data-color-theme="light-high-contrast"] {
+  --ds-color-alias-1: var(--ds-color-blue-6);
+  --ds-color-alias-2: var(--ds-color-alias-1);
+  --ds-color-alias-3: var(--ds-color-alias-2);
+  --ds-color-alias-4: var(--ds-color-alias-3);
+  --ds-color-alias-5: var(--ds-color-alias-4);
   --ds-color-blue-0: rgb(87.451% 96.863% 100%);
   --ds-color-blue-1: rgb(61.176% 84.314% 100%);
   --ds-color-blue-2: rgb(40.392% 70.196% 99.216%);
@@ -212,14 +235,7 @@
   --ds-color-blue-4: rgb(6.6667% 40.784% 89.02%);
   --ds-color-blue-5: rgb(1.1765% 28.627% 70.588%);
   --ds-color-blue-6: rgb(0.78431% 23.137% 58.431%);
-  --ds-color-alias-1: var(--ds-color-blue-6);
-  --ds-color-alias-2: var(--ds-color-alias-1);
-  --ds-color-alias-3: var(--ds-color-alias-2);
-  --ds-color-alias-4: var(--ds-color-alias-3);
-  --ds-color-alias-5: var(--ds-color-alias-4);
-  --ds-color-text-action: var(--ds-color-blue-6);
   --ds-color-blue-7: rgb(0.78431% 18.431% 47.843%);
-  --ds-color-control-border-focus: var(--ds-color-blue-7);
   --ds-color-blue-8: rgb(1.1765% 14.51% 38.824%);
   --ds-color-blue-9: rgb(0.78431% 10.196% 29.02%);
   --ds-color-hdr-blue: oklch(54.35% 0.2531 262.1);
@@ -241,6 +257,11 @@
 }
 
 [data-color-theme="dark-dimmed"] {
+  --ds-color-alias-1: var(--ds-color-blue-6);
+  --ds-color-alias-2: var(--ds-color-alias-1);
+  --ds-color-alias-3: var(--ds-color-alias-2);
+  --ds-color-alias-4: var(--ds-color-alias-3);
+  --ds-color-alias-5: var(--ds-color-alias-4);
   --ds-color-blue-0: rgb(77.647% 90.196% 100%);
   --ds-color-blue-1: rgb(58.824% 81.569% 100%);
   --ds-color-blue-2: rgb(42.353% 71.373% 100%);
@@ -248,14 +269,7 @@
   --ds-color-blue-4: rgb(25.49% 51.765% 89.412%);
   --ds-color-blue-5: rgb(19.216% 42.745% 79.216%);
   --ds-color-blue-6: rgb(14.51% 35.294% 69.804%);
-  --ds-color-alias-1: var(--ds-color-blue-6);
-  --ds-color-alias-2: var(--ds-color-alias-1);
-  --ds-color-alias-3: var(--ds-color-alias-2);
-  --ds-color-alias-4: var(--ds-color-alias-3);
-  --ds-color-alias-5: var(--ds-color-alias-4);
-  --ds-color-text-action: var(--ds-color-blue-6);
   --ds-color-blue-7: rgb(10.588% 29.412% 56.863%);
-  --ds-color-control-border-focus: var(--ds-color-blue-7);
   --ds-color-blue-8: rgb(7.8431% 23.922% 47.451%);
   --ds-color-blue-9: rgb(5.8824% 17.647% 36.078%);
   --ds-color-hdr-blue: oklch(61.77% 0.161 257.75);
@@ -263,6 +277,11 @@
 }
 
 [data-color-theme="dark-high-contrast"] {
+  --ds-color-alias-1: var(--ds-color-blue-6);
+  --ds-color-alias-2: var(--ds-color-alias-1);
+  --ds-color-alias-3: var(--ds-color-alias-2);
+  --ds-color-alias-4: var(--ds-color-alias-3);
+  --ds-color-alias-5: var(--ds-color-alias-4);
   --ds-color-blue-0: rgb(79.216% 91.765% 100%);
   --ds-color-blue-1: rgb(67.843% 86.275% 100%);
   --ds-color-blue-2: rgb(56.863% 79.608% 100%);
@@ -270,14 +289,7 @@
   --ds-color-blue-4: rgb(25.098% 61.961% 100%);
   --ds-color-blue-5: rgb(25.098% 61.961% 100%);
   --ds-color-blue-6: rgb(19.216% 54.51% 97.255%);
-  --ds-color-alias-1: var(--ds-color-blue-6);
-  --ds-color-alias-2: var(--ds-color-alias-1);
-  --ds-color-alias-3: var(--ds-color-alias-2);
-  --ds-color-alias-4: var(--ds-color-alias-3);
-  --ds-color-alias-5: var(--ds-color-alias-4);
-  --ds-color-text-action: var(--ds-color-blue-6);
   --ds-color-blue-7: rgb(14.902% 44.706% 95.294%);
-  --ds-color-control-border-focus: var(--ds-color-blue-7);
   --ds-color-blue-8: rgb(11.765% 37.647% 83.529%);
   --ds-color-blue-9: rgb(9.8039% 30.98% 69.412%);
   --ds-color-hdr-blue: oklch(69.05% 0.1695 249.8);
@@ -299,6 +311,11 @@
 }
 
 [data-color-theme="dark-colorblind"] {
+  --ds-color-alias-1: var(--ds-color-blue-6);
+  --ds-color-alias-2: var(--ds-color-alias-1);
+  --ds-color-alias-3: var(--ds-color-alias-2);
+  --ds-color-alias-4: var(--ds-color-alias-3);
+  --ds-color-alias-5: var(--ds-color-alias-4);
   --ds-color-blue-0: rgb(79.216% 90.98% 100%);
   --ds-color-blue-1: rgb(64.706% 83.922% 100%);
   --ds-color-blue-2: rgb(47.451% 75.294% 100%);
@@ -306,14 +323,7 @@
   --ds-color-blue-4: rgb(21.961% 54.51% 99.216%);
   --ds-color-blue-5: rgb(12.157% 43.529% 92.157%);
   --ds-color-blue-6: rgb(6.6667% 34.51% 78.039%);
-  --ds-color-alias-1: var(--ds-color-blue-6);
-  --ds-color-alias-2: var(--ds-color-alias-1);
-  --ds-color-alias-3: var(--ds-color-alias-2);
-  --ds-color-alias-4: var(--ds-color-alias-3);
-  --ds-color-alias-5: var(--ds-color-alias-4);
-  --ds-color-text-action: var(--ds-color-blue-6);
   --ds-color-blue-7: rgb(5.098% 25.49% 61.569%);
-  --ds-color-control-border-focus: var(--ds-color-blue-7);
   --ds-color-blue-8: rgb(4.7059% 17.647% 41.961%);
   --ds-color-blue-9: rgb(1.9608% 11.373% 30.196%);
   --ds-color-hdr-blue: oklch(63.79% 0.1969 255.8);

--- a/packages/plugin-css/test/fixtures/mode-type-dimension/index.want.css
+++ b/packages/plugin-css/test/fixtures/mode-type-dimension/index.want.css
@@ -23,15 +23,15 @@
 
 @media (width >= 600px) {
   :root {
+    --ds-control-default-size: var(--ds-space-600);
+    --ds-control-small-size: var(--ds-space-500);
     --ds-space-000: 0.25rem;
     --ds-space-100: 0.375rem;
     --ds-space-200: 0.75rem;
     --ds-space-300: 1rem;
     --ds-space-400: 1.25rem;
     --ds-space-500: 1.75rem;
-    --ds-control-small-size: var(--ds-space-500);
     --ds-space-600: 2.5rem;
-    --ds-control-default-size: var(--ds-space-600);
     --ds-space-700: 3.5rem;
     --ds-space-800: 4rem;
     --ds-space-900: 6rem;


### PR DESCRIPTION
## Changes

Fixes another bug related to token aliasing. In this scenario, say you have a primitive token with multiple modes, and your semantic tokens simply reference them. These would accidentally get dropped in the hoisting.

#719 didn’t actually fix the problem, it actually just put a bandaid over it. This PR should fix the problem more holistically.

## How to Review

- Tests updated
