### PR TITLE
docs: Update shadow guide links

### DIFF
--- a/www/src/pages/docs/0.x/reference/tokens.md
+++ b/www/src/pages/docs/0.x/reference/tokens.md
@@ -485,7 +485,7 @@ A composite type combining [dimension](#dimension) with a [color](#color) to for
 
 ### Tips & recommendations
 
-- For smoother shadows, try [layering multiple](https://shadows.brumm.af/).
+- For smoother shadows, try [layering multiple](https://www.joshwcomeau.com/css/designing-shadows/).
 
 ## Gradient
 

--- a/www/src/pages/docs/reference/tokens.md
+++ b/www/src/pages/docs/reference/tokens.md
@@ -485,7 +485,7 @@ A composite type combining [dimension](#dimension) with a [color](#color) to for
 
 ### Tips & recommendations
 
-- For smoother shadows, try [layering multiple](https://shadows.brumm.af/).
+- For smoother shadows, try [layering multiple](https://www.joshwcomeau.com/css/designing-shadows/).
 
 ## Gradient
 


### PR DESCRIPTION
## Changes

Updates a dead link in the docs for shadows and replaces it with the [Josh Comeau blog post](https://www.joshwcomeau.com/css/designing-shadows/).

[Related Issue](https://github.com/terrazzoapp/terrazzo/issues/722#issuecomment-4240070422)

## How to Review

- Confirm link is correct in PR
- Visit docs page for /docs/reference/tokens/#tips--recommendations-5